### PR TITLE
Fix OCI container logs and add live tail

### DIFF
--- a/tui/internal/tui/manage/model.go
+++ b/tui/internal/tui/manage/model.go
@@ -44,6 +44,8 @@ type logsResult struct {
 	err     error
 }
 
+type logTickMsg time.Time
+
 type detailResult struct {
 	detail *incus.ContainerDetail
 	err    error
@@ -63,6 +65,8 @@ type Model struct {
 	subview     subview
 	viewport    viewport.Model
 	detail      *incus.ContainerDetail
+	logFollow   bool   // auto-scroll to bottom
+	logContent  string // current log content for detecting changes
 	message     string
 	err         error
 	done        bool
@@ -166,7 +170,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.subview = subviewLogs
-		m.viewport.SetContent(msg.content)
+		if msg.content != m.logContent {
+			m.logContent = msg.content
+			m.viewport.SetContent(msg.content)
+			if m.logFollow {
+				m.viewport.GotoBottom()
+			}
+		}
+		if m.logFollow {
+			return m, m.logTick()
+		}
+		return m, nil
+
+	case logTickMsg:
+		if m.subview == subviewLogs && m.logFollow {
+			return m, m.fetchLogs()
+		}
 		return m, nil
 
 	case tea.KeyMsg:
@@ -192,8 +211,21 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.subview {
 	case subviewLogs:
 		if key == "esc" || key == "q" {
+			m.logFollow = false
 			m.subview = subviewMenu
 			return m, nil
+		}
+		if key == "f" {
+			m.logFollow = !m.logFollow
+			if m.logFollow {
+				m.viewport.GotoBottom()
+				return m, m.fetchLogs()
+			}
+			return m, nil
+		}
+		// Manual scrolling disables follow
+		if key == "up" || key == "down" || key == "pgup" || key == "pgdown" {
+			m.logFollow = false
 		}
 		var cmd tea.Cmd
 		m.viewport, cmd = m.viewport.Update(msg)
@@ -293,6 +325,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "l":
 			m.busy = true
 			m.message = ""
+			m.logFollow = true
+			m.logContent = ""
 			return m, m.fetchLogs()
 
 		case "e":
@@ -437,7 +471,11 @@ func (m Model) View() string {
 		b.WriteString("\n")
 		b.WriteString(m.viewport.View())
 		b.WriteString("\n")
-		b.WriteString(dimStyle.Render("[esc] Back  [↑↓] Scroll"))
+		followStatus := "[f] Follow: off"
+		if m.logFollow {
+			followStatus = "[f] Follow: on"
+		}
+		b.WriteString(dimStyle.Render(fmt.Sprintf("[esc] Back  [↑↓] Scroll  %s", followStatus)))
 		return b.String()
 	}
 
@@ -748,6 +786,12 @@ func (m Model) restartService() tea.Cmd {
 
 		return actionResult{msg: fmt.Sprintf("Restarted services: %s", strings.Join(restarted, ", "))}
 	}
+}
+
+func (m Model) logTick() tea.Cmd {
+	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+		return logTickMsg(t)
+	})
 }
 
 func (m Model) fetchLogs() tea.Cmd {


### PR DESCRIPTION
## Summary

Closes #14

### OCI Container Log Support
OCI containers don't have systemd/journalctl. Log fetching now tries:
1. `journalctl` (system containers with systemd)
2. `/var/log/incus/<name>/console.log` on the host (OCI containers — Incus captures stdout/stderr here)
3. `/var/log/syslog` (last resort)

### Live Tail with Follow Mode
- Log viewer starts in follow mode (auto-refreshes every 2s, scrolls to bottom)
- Press `[f]` to toggle follow on/off
- Manual scrolling (arrows, pgup/pgdown) automatically pauses follow
- Only re-renders viewport when content changes
- Follow status shown in help bar: `[f] Follow: on/off`

## Tested

- [x] OCI container logs visible via console.log
- [x] System container logs via journalctl
- [x] Follow mode auto-refreshes
- [x] Manual scroll pauses follow
- [x] Toggle follow with [f]


🤖 Generated with [Claude Code](https://claude.com/claude-code)