### PR TITLE
Add freedb deploy CLI for automated CD

### DIFF
--- a/platform/scripts/incus.sh
+++ b/platform/scripts/incus.sh
@@ -111,6 +111,7 @@ if [ -n "$TOKEN" ]; then
   AUTH=$(echo -n "oauth2accesstoken:${TOKEN}" | base64 -w0)
   cat << AUTHEOF
 {
+  "_updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "auths": {
     "us-central1-docker.pkg.dev": {
       "auth": "${AUTH}"
@@ -119,7 +120,7 @@ if [ -n "$TOKEN" ]; then
 }
 AUTHEOF
 else
-  echo '{"auths": {}}'
+  echo "{\"_updated\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"auths\": {}}"
 fi
 HELPER
   sudo chmod +x /usr/local/bin/freedb-registry-auth.sh
@@ -168,6 +169,7 @@ if [ -n "\$TOKEN" ]; then
   AUTH=\$(echo -n "AWS:\${TOKEN}" | base64 -w0)
   cat << AUTHEOF
 {
+  "_updated": "\$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "auths": {
     "${ECR_HOST}": {
       "auth": "\${AUTH}"
@@ -176,7 +178,7 @@ if [ -n "\$TOKEN" ]; then
 }
 AUTHEOF
 else
-  echo '{"auths": {}}'
+  echo "{\"_updated\": \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"auths\": {}}"
 fi
 HELPER
         sudo chmod +x /usr/local/bin/freedb-registry-auth.sh

--- a/tui/internal/deploy/deploy.go
+++ b/tui/internal/deploy/deploy.go
@@ -1,0 +1,207 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/freedb-tui/internal/registry"
+	"github.com/danbiagini/freedb-tui/internal/traefik"
+)
+
+type Result struct {
+	Status     string `json:"status"`
+	App        string `json:"app"`
+	Image      string `json:"image"`
+	Container  string `json:"container"`
+	IP         string `json:"ip"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+type Options struct {
+	AppName string
+	Image   string // full image ref (e.g., ecr:myapp:v1.2.3)
+	Tag     string // just the tag (uses existing image base)
+	DryRun  bool
+	JSON    bool
+}
+
+func Run(opts Options) int {
+	start := time.Now()
+
+	log := func(format string, args ...any) {
+		if !opts.JSON {
+			fmt.Printf(format+"\n", args...)
+		}
+	}
+
+	fail := func(code int, format string, args ...any) int {
+		msg := fmt.Sprintf(format, args...)
+		if opts.JSON {
+			r := Result{
+				Status:     "error",
+				App:        opts.AppName,
+				Error:      msg,
+				DurationMs: time.Since(start).Milliseconds(),
+			}
+			json.NewEncoder(os.Stdout).Encode(r)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+		}
+		return code
+	}
+
+	// Load registry
+	reg, err := registry.Load("/etc/freedb/registry.json")
+	if err != nil {
+		return fail(1, "loading registry: %v", err)
+	}
+
+	app, ok := reg.Get(opts.AppName)
+	if !ok {
+		return fail(2, "app %q not found in registry", opts.AppName)
+	}
+
+	// Resolve image
+	image := opts.Image
+	if image == "" && opts.Tag != "" {
+		// Use existing image base with new tag
+		img := app.Image
+		if idx := strings.LastIndex(img, ":"); idx > 0 {
+			after := img[idx+1:]
+			if !strings.Contains(after, "/") {
+				img = img[:idx]
+			}
+		}
+		image = img + ":" + opts.Tag
+	}
+	if image == "" {
+		return fail(1, "either --image or --tag is required")
+	}
+
+	log("Deploying %s with %s...", opts.AppName, image)
+
+	if opts.DryRun {
+		log("  (dry run — no changes made)")
+		log("  Would update %s from %s to %s", opts.AppName, app.Image, image)
+		log("  Container: %s", app.ContainerName)
+		log("  Domain: %s", app.Domain)
+		if opts.JSON {
+			r := Result{
+				Status:     "dry_run",
+				App:        opts.AppName,
+				Image:      image,
+				DurationMs: time.Since(start).Milliseconds(),
+			}
+			json.NewEncoder(os.Stdout).Encode(r)
+		}
+		return 0
+	}
+
+	// Acquire deploy lock
+	log("  Acquiring deploy lock...")
+	lock, err := AcquireLock()
+	if err != nil {
+		return fail(3, "%v", err)
+	}
+	defer lock.Release()
+
+	// Connect to incus
+	ic, err := incus.Connect("")
+	if err != nil {
+		return fail(1, "connecting to incus: %v", err)
+	}
+
+	ctx := context.Background()
+	timestamp := time.Now().Format("0102-1504")
+	newName := opts.AppName + "-" + timestamp
+
+	// Resolve actual container name
+	oldContainerName := opts.AppName
+	if app.ContainerName != "" {
+		oldContainerName = app.ContainerName
+	}
+
+	// 1. Save env vars
+	log("  Saving environment variables...")
+	envVars, err := ic.GetEnvVars(ctx, oldContainerName)
+	if err != nil {
+		envVars = make(map[string]string)
+	}
+	log("  Found %d environment variables", len(envVars))
+
+	// 2. Delete cached image
+	log("  Clearing image cache...")
+	_ = ic.DeleteCachedImage(ctx, image)
+
+	// 3. Create container without starting
+	log("  Pulling image and creating container %s...", newName)
+	if err := ic.InitOCI(ctx, newName, image); err != nil {
+		return fail(1, "creating container: %v", err)
+	}
+
+	// 4. Restore env vars before starting
+	if len(envVars) > 0 {
+		log("  Restoring environment variables...")
+		if err := ic.RestoreEnvVars(ctx, newName, envVars); err != nil {
+			_ = ic.DeleteContainer(ctx, newName)
+			return fail(1, "restoring env vars: %v", err)
+		}
+	}
+
+	// 5. Start container
+	log("  Starting container...")
+	if err := ic.StartContainer(ctx, newName); err != nil {
+		_ = ic.DeleteContainer(ctx, newName)
+		return fail(1, "starting container: %v", err)
+	}
+
+	// 6. Wait for IP
+	log("  Waiting for IP...")
+	newIP, err := ic.WaitForIP(ctx, newName, 30*time.Second)
+	if err != nil {
+		_ = ic.DeleteContainer(ctx, newName)
+		return fail(1, "waiting for IP: %v", err)
+	}
+	log("  Container running at %s", newIP)
+
+	// 7. Switch Traefik route
+	if app.Domain != "" {
+		log("  Switching Traefik route...")
+		if err := traefik.PushRoute(ic, opts.AppName, app.Domain, newIP, app.Port, app.TLS); err != nil {
+			_ = ic.DeleteContainer(ctx, newName)
+			return fail(1, "updating route: %v", err)
+		}
+	}
+
+	// 8. Delete old container
+	log("  Removing old container %s...", oldContainerName)
+	_ = ic.DeleteContainer(ctx, oldContainerName)
+
+	// 9. Update registry
+	_ = reg.UpdateIP(opts.AppName, newIP)
+	_ = reg.UpdateImage(opts.AppName, image)
+	_ = reg.UpdateContainerName(opts.AppName, newName)
+
+	duration := time.Since(start)
+	log("  Done in %s.", duration.Truncate(time.Millisecond))
+
+	if opts.JSON {
+		r := Result{
+			Status:     "ok",
+			App:        opts.AppName,
+			Image:      image,
+			Container:  newName,
+			IP:         newIP,
+			DurationMs: duration.Milliseconds(),
+		}
+		json.NewEncoder(os.Stdout).Encode(r)
+	}
+
+	return 0
+}

--- a/tui/internal/deploy/deploy.go
+++ b/tui/internal/deploy/deploy.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/danbiagini/freedb-tui/internal/incus"
 	"github.com/danbiagini/freedb-tui/internal/registry"
-	"github.com/danbiagini/freedb-tui/internal/traefik"
 )
 
 type Result struct {
@@ -25,10 +24,29 @@ type Result struct {
 
 type Options struct {
 	AppName string
-	Image   string // full image ref (e.g., ecr:myapp:v1.2.3)
-	Tag     string // just the tag (uses existing image base)
+	Image   string
+	Tag     string
 	DryRun  bool
 	JSON    bool
+}
+
+// ResolveImage determines the full image ref from Options and the existing app config
+func ResolveImage(opts Options, app *registry.App) (string, error) {
+	image := opts.Image
+	if image == "" && opts.Tag != "" {
+		img := app.Image
+		if idx := strings.LastIndex(img, ":"); idx > 0 {
+			after := img[idx+1:]
+			if !strings.Contains(after, "/") {
+				img = img[:idx]
+			}
+		}
+		image = img + ":" + opts.Tag
+	}
+	if image == "" {
+		return "", fmt.Errorf("either --image or --tag is required")
+	}
+	return image, nil
 }
 
 func Run(opts Options) int {
@@ -68,20 +86,9 @@ func Run(opts Options) int {
 	}
 
 	// Resolve image
-	image := opts.Image
-	if image == "" && opts.Tag != "" {
-		// Use existing image base with new tag
-		img := app.Image
-		if idx := strings.LastIndex(img, ":"); idx > 0 {
-			after := img[idx+1:]
-			if !strings.Contains(after, "/") {
-				img = img[:idx]
-			}
-		}
-		image = img + ":" + opts.Tag
-	}
-	if image == "" {
-		return fail(1, "either --image or --tag is required")
+	image, err := ResolveImage(opts, app)
+	if err != nil {
+		return fail(1, "%v", err)
 	}
 
 	log("Deploying %s with %s...", opts.AppName, image)
@@ -117,76 +124,20 @@ func Run(opts Options) int {
 		return fail(1, "connecting to incus: %v", err)
 	}
 
-	ctx := context.Background()
-	timestamp := time.Now().Format("0102-1504")
-	newName := opts.AppName + "-" + timestamp
-
-	// Resolve actual container name
-	oldContainerName := opts.AppName
-	if app.ContainerName != "" {
-		oldContainerName = app.ContainerName
-	}
-
-	// 1. Save env vars
-	log("  Saving environment variables...")
-	envVars, err := ic.GetEnvVars(ctx, oldContainerName)
+	// Run the update using the shared engine
+	result, err := Update(context.Background(), UpdateParams{
+		AppName:     opts.AppName,
+		Image:       image,
+		App:         app,
+		IncusClient: ic,
+		Registry:    reg,
+		OnProgress: func(msg string) {
+			log("  %s", msg)
+		},
+	})
 	if err != nil {
-		envVars = make(map[string]string)
+		return fail(1, "%v", err)
 	}
-	log("  Found %d environment variables", len(envVars))
-
-	// 2. Delete cached image
-	log("  Clearing image cache...")
-	_ = ic.DeleteCachedImage(ctx, image)
-
-	// 3. Create container without starting
-	log("  Pulling image and creating container %s...", newName)
-	if err := ic.InitOCI(ctx, newName, image); err != nil {
-		return fail(1, "creating container: %v", err)
-	}
-
-	// 4. Restore env vars before starting
-	if len(envVars) > 0 {
-		log("  Restoring environment variables...")
-		if err := ic.RestoreEnvVars(ctx, newName, envVars); err != nil {
-			_ = ic.DeleteContainer(ctx, newName)
-			return fail(1, "restoring env vars: %v", err)
-		}
-	}
-
-	// 5. Start container
-	log("  Starting container...")
-	if err := ic.StartContainer(ctx, newName); err != nil {
-		_ = ic.DeleteContainer(ctx, newName)
-		return fail(1, "starting container: %v", err)
-	}
-
-	// 6. Wait for IP
-	log("  Waiting for IP...")
-	newIP, err := ic.WaitForIP(ctx, newName, 30*time.Second)
-	if err != nil {
-		_ = ic.DeleteContainer(ctx, newName)
-		return fail(1, "waiting for IP: %v", err)
-	}
-	log("  Container running at %s", newIP)
-
-	// 7. Switch Traefik route
-	if app.Domain != "" {
-		log("  Switching Traefik route...")
-		if err := traefik.PushRoute(ic, opts.AppName, app.Domain, newIP, app.Port, app.TLS); err != nil {
-			_ = ic.DeleteContainer(ctx, newName)
-			return fail(1, "updating route: %v", err)
-		}
-	}
-
-	// 8. Delete old container
-	log("  Removing old container %s...", oldContainerName)
-	_ = ic.DeleteContainer(ctx, oldContainerName)
-
-	// 9. Update registry
-	_ = reg.UpdateIP(opts.AppName, newIP)
-	_ = reg.UpdateImage(opts.AppName, image)
-	_ = reg.UpdateContainerName(opts.AppName, newName)
 
 	duration := time.Since(start)
 	log("  Done in %s.", duration.Truncate(time.Millisecond))
@@ -196,8 +147,8 @@ func Run(opts Options) int {
 			Status:     "ok",
 			App:        opts.AppName,
 			Image:      image,
-			Container:  newName,
-			IP:         newIP,
+			Container:  result.NewContainer,
+			IP:         result.NewIP,
 			DurationMs: duration.Milliseconds(),
 		}
 		json.NewEncoder(os.Stdout).Encode(r)

--- a/tui/internal/deploy/deploy_test.go
+++ b/tui/internal/deploy/deploy_test.go
@@ -1,0 +1,72 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/danbiagini/freedb-tui/internal/registry"
+)
+
+func TestResolveImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      Options
+		app       *registry.App
+		want      string
+		wantError bool
+	}{
+		{
+			name: "explicit image",
+			opts: Options{Image: "ecr:myapp:v1.2.3"},
+			app:  &registry.App{Image: "ecr:myapp:latest"},
+			want: "ecr:myapp:v1.2.3",
+		},
+		{
+			name: "tag only with colon in existing",
+			opts: Options{Tag: "v2.0"},
+			app:  &registry.App{Image: "ecr:myapp:latest"},
+			want: "ecr:myapp:v2.0",
+		},
+		{
+			name: "tag only without existing tag",
+			opts: Options{Tag: "v1.0"},
+			app:  &registry.App{Image: "docker.io/myapp"},
+			want: "docker.io/myapp:v1.0",
+		},
+		{
+			name: "tag with docker.io image",
+			opts: Options{Tag: "v3"},
+			app:  &registry.App{Image: "docker.io/traefik/whoami:latest"},
+			want: "docker.io/traefik/whoami:v3",
+		},
+		{
+			name:      "neither image nor tag",
+			opts:      Options{},
+			app:       &registry.App{Image: "ecr:myapp:latest"},
+			wantError: true,
+		},
+		{
+			name: "image takes precedence over tag",
+			opts: Options{Image: "ecr:myapp:v1", Tag: "v2"},
+			app:  &registry.App{Image: "ecr:myapp:latest"},
+			want: "ecr:myapp:v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveImage(tt.opts, tt.app)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveImage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tui/internal/deploy/engine.go
+++ b/tui/internal/deploy/engine.go
@@ -1,0 +1,118 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/freedb-tui/internal/registry"
+	"github.com/danbiagini/freedb-tui/internal/traefik"
+)
+
+// UpdateParams contains everything needed to perform a zero-downtime update
+type UpdateParams struct {
+	AppName          string
+	Image            string
+	App              *registry.App
+	IncusClient      *incus.Client
+	Registry         *registry.AppRegistry
+	OnProgress       func(msg string) // optional progress callback
+}
+
+// UpdateResult contains the outcome of an update
+type UpdateResult struct {
+	NewContainer string
+	NewIP        string
+}
+
+// Update performs a zero-downtime blue-green deployment.
+// This is the shared core logic used by both the TUI and CLI.
+func Update(ctx context.Context, params UpdateParams) (*UpdateResult, error) {
+	ic := params.IncusClient
+	app := params.App
+	reg := params.Registry
+	name := params.AppName
+	image := params.Image
+
+	progress := func(msg string) {
+		if params.OnProgress != nil {
+			params.OnProgress(msg)
+		}
+	}
+
+	timestamp := time.Now().Format("0102-1504")
+	newName := name + "-" + timestamp
+
+	// Resolve actual container name
+	oldContainerName := name
+	if app.ContainerName != "" {
+		oldContainerName = app.ContainerName
+	}
+
+	// 1. Save env vars
+	progress("Saving environment variables...")
+	envVars, err := ic.GetEnvVars(ctx, oldContainerName)
+	if err != nil {
+		envVars = make(map[string]string)
+	}
+	progress(fmt.Sprintf("Found %d environment variables", len(envVars)))
+
+	// 2. Delete cached image
+	progress("Clearing image cache...")
+	_ = ic.DeleteCachedImage(ctx, image)
+
+	// 3. Create container without starting
+	progress(fmt.Sprintf("Pulling image and creating container %s...", newName))
+	if err := ic.InitOCI(ctx, newName, image); err != nil {
+		return nil, fmt.Errorf("creating container: %w", err)
+	}
+
+	// 4. Restore env vars before starting
+	if len(envVars) > 0 {
+		progress("Restoring environment variables...")
+		if err := ic.RestoreEnvVars(ctx, newName, envVars); err != nil {
+			_ = ic.DeleteContainer(ctx, newName)
+			return nil, fmt.Errorf("restoring env vars: %w", err)
+		}
+	}
+
+	// 5. Start container
+	progress("Starting container...")
+	if err := ic.StartContainer(ctx, newName); err != nil {
+		_ = ic.DeleteContainer(ctx, newName)
+		return nil, fmt.Errorf("starting container: %w", err)
+	}
+
+	// 6. Wait for IP
+	progress("Waiting for IP...")
+	newIP, err := ic.WaitForIP(ctx, newName, 30*time.Second)
+	if err != nil {
+		_ = ic.DeleteContainer(ctx, newName)
+		return nil, fmt.Errorf("waiting for IP: %w", err)
+	}
+	progress(fmt.Sprintf("Container running at %s", newIP))
+
+	// 7. Switch Traefik route
+	if app.Domain != "" {
+		progress("Switching Traefik route...")
+		if err := traefik.PushRoute(ic, name, app.Domain, newIP, app.Port, app.TLS); err != nil {
+			_ = ic.DeleteContainer(ctx, newName)
+			return nil, fmt.Errorf("updating route: %w", err)
+		}
+	}
+
+	// 8. Delete old container
+	progress(fmt.Sprintf("Removing old container %s...", oldContainerName))
+	_ = ic.DeleteContainer(ctx, oldContainerName)
+
+	// 9. Update registry
+	_ = reg.UpdateIP(name, newIP)
+	_ = reg.UpdateImage(name, image)
+	_ = reg.UpdateContainerName(name, newName)
+
+	return &UpdateResult{
+		NewContainer: newName,
+		NewIP:        newIP,
+	}, nil
+}

--- a/tui/internal/deploy/lock.go
+++ b/tui/internal/deploy/lock.go
@@ -3,13 +3,15 @@ package deploy
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
 
-const lockPath = "/var/lib/freedb/deploy.lock"
+var lockPath = "/var/lib/freedb/deploy.lock"
+
 const lockTimeout = 30 * time.Second
 
 type Lock struct {
@@ -20,7 +22,7 @@ type Lock struct {
 // Waits up to 30 seconds for an existing lock to release.
 // Returns the lock (must call Release when done) or an error.
 func AcquireLock() (*Lock, error) {
-	if err := os.MkdirAll("/var/lib/freedb", 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
 		return nil, fmt.Errorf("creating lock directory: %w", err)
 	}
 

--- a/tui/internal/deploy/lock.go
+++ b/tui/internal/deploy/lock.go
@@ -1,0 +1,102 @@
+package deploy
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const lockPath = "/var/lib/freedb/deploy.lock"
+const lockTimeout = 30 * time.Second
+
+type Lock struct {
+	file *os.File
+}
+
+// AcquireLock attempts to acquire the deploy lock.
+// Waits up to 30 seconds for an existing lock to release.
+// Returns the lock (must call Release when done) or an error.
+func AcquireLock() (*Lock, error) {
+	if err := os.MkdirAll("/var/lib/freedb", 0755); err != nil {
+		return nil, fmt.Errorf("creating lock directory: %w", err)
+	}
+
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		// Try to clean up stale locks
+		cleanStaleLock()
+
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err == nil {
+			// Write PID and timestamp for debugging
+			content := fmt.Sprintf("%d\n%s\n", os.Getpid(), time.Now().Format(time.RFC3339))
+			f.WriteString(content)
+			return &Lock{file: f}, nil
+		}
+
+		if time.Now().After(deadline) {
+			// Read lock info for the error message
+			info := readLockInfo()
+			return nil, fmt.Errorf("deploy lock timeout after %s — another deploy is in progress%s", lockTimeout, info)
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// Release releases the deploy lock.
+func (l *Lock) Release() {
+	if l.file != nil {
+		l.file.Close()
+	}
+	os.Remove(lockPath)
+}
+
+// cleanStaleLock removes the lock file if the owning process is no longer running.
+func cleanStaleLock() {
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return // no lock file
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 1 {
+		return
+	}
+
+	pid, err := strconv.Atoi(lines[0])
+	if err != nil {
+		// Corrupted lock file, remove it
+		os.Remove(lockPath)
+		return
+	}
+
+	// Check if the process is still running
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		os.Remove(lockPath)
+		return
+	}
+
+	// On Unix, FindProcess always succeeds. Send signal 0 to check if process exists.
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		// Process is gone, remove stale lock
+		os.Remove(lockPath)
+	}
+}
+
+func readLockInfo() string {
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return ""
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) >= 2 {
+		return fmt.Sprintf(" (pid %s, started %s)", lines[0], lines[1])
+	}
+	return ""
+}

--- a/tui/internal/deploy/lock_test.go
+++ b/tui/internal/deploy/lock_test.go
@@ -1,0 +1,49 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func withTempLock(t *testing.T) func() {
+	origPath := lockPath
+	dir := t.TempDir()
+	lockPath = filepath.Join(dir, "deploy.lock")
+	return func() { lockPath = origPath }
+}
+
+func TestAcquireAndReleaseLock(t *testing.T) {
+	defer withTempLock(t)()
+
+	lock, err := AcquireLock()
+	if err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+
+	// Lock file should exist
+	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
+		t.Fatal("lock file not created")
+	}
+
+	lock.Release()
+
+	// Lock file should be gone
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatal("lock file not removed after release")
+	}
+}
+
+func TestStaleLockCleanup(t *testing.T) {
+	defer withTempLock(t)()
+
+	// Write a lock with a non-existent PID
+	os.WriteFile(lockPath, []byte("999999999\n2026-01-01T00:00:00Z\n"), 0644)
+
+	// Should clean up stale lock and acquire
+	lock, err := AcquireLock()
+	if err != nil {
+		t.Fatalf("AcquireLock should clean stale lock: %v", err)
+	}
+	lock.Release()
+}

--- a/tui/internal/registry/registry.go
+++ b/tui/internal/registry/registry.go
@@ -75,6 +75,29 @@ func (r *AppRegistry) Get(name string) (*App, bool) {
 	return app, ok
 }
 
+// Reload re-reads the registry from disk, picking up changes made by other processes
+func (r *AppRegistry) Reload() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	data, err := os.ReadFile(r.FilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var fresh AppRegistry
+	if err := json.Unmarshal(data, &fresh); err != nil {
+		return err
+	}
+	if fresh.Apps != nil {
+		r.Apps = fresh.Apps
+	}
+	return nil
+}
+
 func (r *AppRegistry) List() []*App {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/tui/internal/tui/dashboard/model.go
+++ b/tui/internal/tui/dashboard/model.go
@@ -279,6 +279,9 @@ func (m Model) refresh() tea.Cmd {
 		// Fetch Traefik metrics (best effort)
 		metrics, _ := traefik.FetchMetrics(m.incusClient, m.cfg.ProxyContainer)
 
+		// Reload registry from disk to pick up changes from CLI deploys
+		_ = m.registry.Reload()
+
 		systemContainers := map[string]bool{
 			m.cfg.ProxyContainer: true,
 			m.cfg.DBContainer:    true,

--- a/tui/internal/tui/manage/model.go
+++ b/tui/internal/tui/manage/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/danbiagini/freedb-tui/internal/db"
+	"github.com/danbiagini/freedb-tui/internal/deploy"
 	"github.com/danbiagini/freedb-tui/internal/incus"
 	"github.com/danbiagini/freedb-tui/internal/registry"
 	"github.com/danbiagini/freedb-tui/internal/traefik"
@@ -866,68 +867,18 @@ func (m Model) updateApp(image string) tea.Cmd {
 			return actionResult{err: fmt.Errorf("no app config found")}
 		}
 
-		ctx := context.Background()
-		timestamp := time.Now().Format("0102-1504") // MMDD-HHMM
-		newName := name + "-" + timestamp
-
-		// Resolve the actual container name (may differ from app name after previous updates)
-		oldContainerName := name
-		if app.ContainerName != "" {
-			oldContainerName = app.ContainerName
-		}
-
-		// 1. Save env vars from the old container
-		envVars, err := ic.GetEnvVars(ctx, oldContainerName)
+		result, err := deploy.Update(context.Background(), deploy.UpdateParams{
+			AppName:     name,
+			Image:       image,
+			App:         app,
+			IncusClient: ic,
+			Registry:    reg,
+		})
 		if err != nil {
-			envVars = make(map[string]string) // continue without env vars
+			return actionResult{err: err}
 		}
 
-		// 2. Delete cached image to force a fresh pull
-		_ = ic.DeleteCachedImage(ctx, image)
-
-		// 3. Create new container WITHOUT starting (need to set env vars first)
-		if err := ic.InitOCI(ctx, newName, image); err != nil {
-			return actionResult{err: fmt.Errorf("creating new container: %w", err)}
-		}
-
-		// 4. Restore env vars BEFORE starting so the app sees them on boot
-		if len(envVars) > 0 {
-			if err := ic.RestoreEnvVars(ctx, newName, envVars); err != nil {
-				_ = ic.DeleteContainer(ctx, newName)
-				return actionResult{err: fmt.Errorf("restoring env vars: %w", err)}
-			}
-		}
-
-		// 5. Start the container now that env vars are configured
-		if err := ic.StartContainer(ctx, newName); err != nil {
-			_ = ic.DeleteContainer(ctx, newName)
-			return actionResult{err: fmt.Errorf("starting new container: %w", err)}
-		}
-
-		// 6. Wait for IP on the new container
-		newIP, err := ic.WaitForIP(ctx, newName, 30*time.Second)
-		if err != nil {
-			_ = ic.DeleteContainer(ctx, newName)
-			return actionResult{err: fmt.Errorf("new container failed to get IP: %w", err)}
-		}
-
-		// 7. Switch Traefik route to the new container (zero-downtime cutover)
-		if app.Domain != "" {
-			if err := traefik.PushRoute(ic, name, app.Domain, newIP, app.Port, app.TLS); err != nil {
-				_ = ic.DeleteContainer(ctx, newName)
-				return actionResult{err: fmt.Errorf("updating route: %w", err)}
-			}
-		}
-
-		// 6. Delete the old container (no longer receiving traffic)
-		_ = ic.DeleteContainer(ctx, oldContainerName)
-
-		// 7. Update registry — keep app name, track new container name
-		_ = reg.UpdateIP(name, newIP)
-		_ = reg.UpdateImage(name, image)
-		_ = reg.UpdateContainerName(name, newName)
-
-		return actionResult{msg: fmt.Sprintf("Updated to %s", image)}
+		return actionResult{msg: fmt.Sprintf("Updated to %s (%s)", image, result.NewContainer)}
 	}
 }
 

--- a/tui/internal/tui/manage/model.go
+++ b/tui/internal/tui/manage/model.go
@@ -867,6 +867,12 @@ func (m Model) updateApp(image string) tea.Cmd {
 			return actionResult{err: fmt.Errorf("no app config found")}
 		}
 
+		lock, err := deploy.AcquireLock()
+		if err != nil {
+			return actionResult{err: fmt.Errorf("another deploy in progress: %w", err)}
+		}
+		defer lock.Release()
+
 		result, err := deploy.Update(context.Background(), deploy.UpdateParams{
 			AppName:     name,
 			Image:       image,

--- a/tui/main.go
+++ b/tui/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danbiagini/freedb-tui/internal/check"
 	"github.com/danbiagini/freedb-tui/internal/config"
+	"github.com/danbiagini/freedb-tui/internal/deploy"
 	"github.com/danbiagini/freedb-tui/internal/incus"
 	"github.com/danbiagini/freedb-tui/internal/registry"
 	"github.com/danbiagini/freedb-tui/internal/tui"
@@ -35,14 +36,10 @@ func main() {
 				}
 			}
 			os.Exit(0)
+		case "deploy":
+			os.Exit(runDeploy(os.Args[2:]))
 		case "--help", "-h", "help":
-			fmt.Println("freedb — FreeDB app manager")
-			fmt.Println()
-			fmt.Println("Usage:")
-			fmt.Println("  sudo freedb              Launch the TUI dashboard")
-			fmt.Println("  sudo freedb check        Run health checks")
-			fmt.Println("  freedb --version         Print version")
-			fmt.Println("  freedb --help            Show this help")
+			printHelp()
 			os.Exit(0)
 		}
 	}
@@ -75,4 +72,97 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error running TUI: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func runDeploy(args []string) int {
+	opts := deploy.Options{}
+
+	i := 0
+	for i < len(args) {
+		switch args[i] {
+		case "--image":
+			if i+1 < len(args) {
+				opts.Image = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: --image requires a value\n")
+				return 1
+			}
+		case "--tag":
+			if i+1 < len(args) {
+				opts.Tag = args[i+1]
+				i += 2
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: --tag requires a value\n")
+				return 1
+			}
+		case "--json":
+			opts.JSON = true
+			i++
+		case "--dry-run":
+			opts.DryRun = true
+			i++
+		case "--help", "-h":
+			printDeployHelp()
+			return 0
+		default:
+			if opts.AppName == "" && !startsWith(args[i], "-") {
+				opts.AppName = args[i]
+				i++
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: unknown argument %q\n", args[i])
+				printDeployHelp()
+				return 1
+			}
+		}
+	}
+
+	if opts.AppName == "" {
+		fmt.Fprintf(os.Stderr, "Error: app name is required\n")
+		printDeployHelp()
+		return 1
+	}
+
+	return deploy.Run(opts)
+}
+
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func printHelp() {
+	fmt.Println("freedb — FreeDB app manager")
+	fmt.Println()
+	fmt.Println("Usage:")
+	fmt.Println("  sudo freedb              Launch the TUI dashboard")
+	fmt.Println("  sudo freedb deploy       Deploy/update an app (for CI/CD)")
+	fmt.Println("  sudo freedb check        Run health checks")
+	fmt.Println("  freedb --version         Print version")
+	fmt.Println("  freedb --help            Show this help")
+	fmt.Println()
+	fmt.Println("Run 'freedb deploy --help' for deploy options.")
+}
+
+func printDeployHelp() {
+	fmt.Println("Usage: sudo freedb deploy <app-name> [options]")
+	fmt.Println()
+	fmt.Println("Deploy or update an existing app with a new container image.")
+	fmt.Println()
+	fmt.Println("Options:")
+	fmt.Println("  --image <ref>    Full image reference (e.g., ecr:myapp:v1.2.3)")
+	fmt.Println("  --tag <tag>      Tag only (uses existing image base from registry)")
+	fmt.Println("  --json           Output result as JSON")
+	fmt.Println("  --dry-run        Show what would happen without executing")
+	fmt.Println("  --help           Show this help")
+	fmt.Println()
+	fmt.Println("Examples:")
+	fmt.Println("  sudo freedb deploy myapp --image ecr:myapp:v1.2.3")
+	fmt.Println("  sudo freedb deploy myapp --tag latest")
+	fmt.Println("  sudo freedb deploy myapp --tag v1.2.3 --json")
+	fmt.Println()
+	fmt.Println("Exit codes:")
+	fmt.Println("  0  Deploy succeeded")
+	fmt.Println("  1  Deploy failed")
+	fmt.Println("  2  App not found in registry")
+	fmt.Println("  3  Deploy lock timeout")
 }

--- a/tui/main.go
+++ b/tui/main.go
@@ -1,16 +1,22 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/danbiagini/freedb-tui/internal/check"
 	"github.com/danbiagini/freedb-tui/internal/config"
+	"github.com/danbiagini/freedb-tui/internal/db"
 	"github.com/danbiagini/freedb-tui/internal/deploy"
 	"github.com/danbiagini/freedb-tui/internal/incus"
 	"github.com/danbiagini/freedb-tui/internal/registry"
+	"github.com/danbiagini/freedb-tui/internal/traefik"
 	"github.com/danbiagini/freedb-tui/internal/tui"
 )
 
@@ -38,6 +44,12 @@ func main() {
 			os.Exit(0)
 		case "deploy":
 			os.Exit(runDeploy(os.Args[2:]))
+		case "list", "ls":
+			os.Exit(runList(os.Args[2:]))
+		case "destroy", "rm":
+			os.Exit(runDestroy(os.Args[2:]))
+		case "status":
+			os.Exit(runStatus(os.Args[2:]))
 		case "--help", "-h", "help":
 			printHelp()
 			os.Exit(0)
@@ -130,17 +142,312 @@ func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
 
+func runList(args []string) int {
+	jsonOutput := false
+	for _, a := range args {
+		if a == "--json" {
+			jsonOutput = true
+		}
+		if a == "--help" || a == "-h" {
+			fmt.Println("Usage: sudo freedb list [--json]")
+			fmt.Println()
+			fmt.Println("List all deployed apps.")
+			return 0
+		}
+	}
+
+	reg, err := registry.Load("/etc/freedb/registry.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading registry: %v\n", err)
+		return 1
+	}
+
+	ic, err := incus.Connect("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error connecting to incus: %v\n", err)
+		return 1
+	}
+
+	apps := reg.List()
+	if len(apps) == 0 {
+		if !jsonOutput {
+			fmt.Println("No apps deployed.")
+		} else {
+			fmt.Println("[]")
+		}
+		return 0
+	}
+
+	if jsonOutput {
+		type appInfo struct {
+			Name      string `json:"name"`
+			Image     string `json:"image"`
+			Domain    string `json:"domain"`
+			Status    string `json:"status"`
+			Container string `json:"container"`
+			IP        string `json:"ip"`
+		}
+		var infos []appInfo
+		for _, app := range apps {
+			cName := app.Name
+			if app.ContainerName != "" {
+				cName = app.ContainerName
+			}
+			status := "unknown"
+			ip := ""
+			if containers, err := ic.ListContainers(context.Background()); err == nil {
+				for _, c := range containers {
+					if c.Name == cName {
+						status = c.Status
+						ip = c.IP
+						break
+					}
+				}
+			}
+			infos = append(infos, appInfo{
+				Name:      app.Name,
+				Image:     app.Image,
+				Domain:    app.Domain,
+				Status:    status,
+				Container: cName,
+				IP:        ip,
+			})
+		}
+		json.NewEncoder(os.Stdout).Encode(infos)
+		return 0
+	}
+
+	// Get container states
+	containers, _ := ic.ListContainers(context.Background())
+	containerMap := make(map[string]incus.ContainerInfo)
+	for _, c := range containers {
+		containerMap[c.Name] = c
+	}
+
+	fmt.Printf("%-20s %-10s %-30s %s\n", "NAME", "STATUS", "DOMAIN", "IMAGE")
+	fmt.Printf("%-20s %-10s %-30s %s\n", "----", "------", "------", "-----")
+	for _, app := range apps {
+		cName := app.Name
+		if app.ContainerName != "" {
+			cName = app.ContainerName
+		}
+		status := "unknown"
+		if c, ok := containerMap[cName]; ok {
+			status = c.Status
+		}
+		// Short image name
+		img := app.Image
+		if parts := strings.Split(img, "/"); len(parts) > 1 {
+			img = parts[len(parts)-1]
+		}
+		fmt.Printf("%-20s %-10s %-30s %s\n", app.Name, status, app.Domain, img)
+	}
+	return 0
+}
+
+func runStatus(args []string) int {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fmt.Println("Usage: sudo freedb status <app-name> [--json]")
+		return 0
+	}
+
+	appName := args[0]
+	jsonOutput := false
+	for _, a := range args[1:] {
+		if a == "--json" {
+			jsonOutput = true
+		}
+	}
+
+	reg, err := registry.Load("/etc/freedb/registry.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading registry: %v\n", err)
+		return 1
+	}
+
+	app, ok := reg.Get(appName)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Error: app %q not found\n", appName)
+		return 2
+	}
+
+	ic, err := incus.Connect("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error connecting to incus: %v\n", err)
+		return 1
+	}
+
+	cName := app.Name
+	if app.ContainerName != "" {
+		cName = app.ContainerName
+	}
+
+	detail, _ := ic.GetContainerDetail(context.Background(), cName)
+	envVars, _ := ic.GetEnvVars(context.Background(), cName)
+
+	if jsonOutput {
+		info := map[string]any{
+			"name":      app.Name,
+			"container": cName,
+			"image":     app.Image,
+			"domain":    app.Domain,
+			"port":      app.Port,
+			"tls":       app.TLS,
+			"has_db":    app.HasDB,
+			"db_name":   app.DBName,
+			"env_vars":  envVars,
+		}
+		if detail != nil {
+			info["status"] = detail.Status
+			info["ip"] = detail.IP
+			info["memory_mb"] = detail.MemUsageMB
+			info["disk_mb"] = detail.DiskUsageMB
+			info["uptime_seconds"] = int(detail.Uptime.Seconds())
+			info["processes"] = detail.Processes
+		}
+		json.NewEncoder(os.Stdout).Encode(info)
+		return 0
+	}
+
+	fmt.Printf("App:        %s\n", app.Name)
+	fmt.Printf("Container:  %s\n", cName)
+	fmt.Printf("Image:      %s\n", app.Image)
+	fmt.Printf("Domain:     %s\n", app.Domain)
+	fmt.Printf("Port:       %d\n", app.Port)
+	fmt.Printf("TLS:        %v\n", app.TLS)
+	if app.HasDB {
+		fmt.Printf("Database:   %s\n", app.DBName)
+	}
+
+	if detail != nil {
+		fmt.Println()
+		fmt.Printf("Status:     %s\n", detail.Status)
+		fmt.Printf("IP:         %s\n", detail.IP)
+		if detail.MemUsageMB > 0 {
+			fmt.Printf("Memory:     %d MB\n", detail.MemUsageMB)
+		}
+		if detail.DiskUsageMB > 0 {
+			fmt.Printf("Disk:       %d MB\n", detail.DiskUsageMB)
+		}
+		if detail.Uptime > 0 {
+			fmt.Printf("Uptime:     %s\n", detail.Uptime.Truncate(time.Second))
+		}
+		if detail.Processes > 0 {
+			fmt.Printf("Processes:  %d\n", detail.Processes)
+		}
+	}
+
+	if len(envVars) > 0 {
+		fmt.Println()
+		fmt.Println("Environment:")
+		for k, v := range envVars {
+			fmt.Printf("  %s=%s\n", k, v)
+		}
+	}
+
+	return 0
+}
+
+func runDestroy(args []string) int {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fmt.Println("Usage: sudo freedb destroy <app-name> [--yes]")
+		fmt.Println()
+		fmt.Println("Delete an app and all its resources (container, route, database).")
+		fmt.Println()
+		fmt.Println("Options:")
+		fmt.Println("  --yes    Skip confirmation prompt")
+		return 0
+	}
+
+	appName := args[0]
+	skipConfirm := false
+	for _, a := range args[1:] {
+		if a == "--yes" || a == "-y" {
+			skipConfirm = true
+		}
+	}
+
+	reg, err := registry.Load("/etc/freedb/registry.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading registry: %v\n", err)
+		return 1
+	}
+
+	app, ok := reg.Get(appName)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Error: app %q not found\n", appName)
+		return 2
+	}
+
+	cName := appName
+	if app.ContainerName != "" {
+		cName = app.ContainerName
+	}
+
+	if !skipConfirm {
+		fmt.Printf("Delete app %q?\n", appName)
+		fmt.Printf("  Container: %s\n", cName)
+		fmt.Printf("  Domain:    %s\n", app.Domain)
+		if app.HasDB {
+			fmt.Printf("  Database:  %s (WILL BE DROPPED)\n", app.DBName)
+		}
+		fmt.Print("\nType 'yes' to confirm: ")
+		var confirm string
+		fmt.Scanln(&confirm)
+		if confirm != "yes" {
+			fmt.Println("Aborted.")
+			return 0
+		}
+	}
+
+	ic, err := incus.Connect("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error connecting to incus: %v\n", err)
+		return 1
+	}
+
+	ctx := context.Background()
+
+	// Delete container
+	fmt.Printf("Deleting container %s...\n", cName)
+	if err := ic.DeleteContainer(ctx, cName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+	}
+
+	// Delete Traefik route
+	fmt.Println("Removing Traefik route...")
+	_ = traefik.DeleteRoute(ic, appName)
+
+	// Drop database
+	if app.HasDB && app.DBName != "" {
+		fmt.Printf("Dropping database %s...\n", app.DBName)
+		_ = db.DropDatabase(ctx, ic, app.DBName)
+	}
+
+	// Remove from registry
+	fmt.Println("Removing from registry...")
+	if err := reg.Remove(appName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+	}
+
+	fmt.Println("Done.")
+	return 0
+}
+
 func printHelp() {
 	fmt.Println("freedb — FreeDB app manager")
 	fmt.Println()
 	fmt.Println("Usage:")
 	fmt.Println("  sudo freedb              Launch the TUI dashboard")
+	fmt.Println("  sudo freedb list         List deployed apps")
+	fmt.Println("  sudo freedb status APP   Show detailed app status")
 	fmt.Println("  sudo freedb deploy       Deploy/update an app (for CI/CD)")
+	fmt.Println("  sudo freedb destroy APP  Delete an app and all its resources")
 	fmt.Println("  sudo freedb check        Run health checks")
 	fmt.Println("  freedb --version         Print version")
 	fmt.Println("  freedb --help            Show this help")
 	fmt.Println()
-	fmt.Println("Run 'freedb deploy --help' for deploy options.")
+	fmt.Println("Run 'freedb <command> --help' for command-specific options.")
 }
 
 func printDeployHelp() {


### PR DESCRIPTION
## Summary

Refs #29

Adds `freedb deploy` subcommand for CI/CD pipelines to deploy apps without the TUI.

### Usage

```bash
sudo freedb deploy myapp --image ecr:myapp:v1.2.3
sudo freedb deploy myapp --tag latest
sudo freedb deploy myapp --tag v1.2.3 --json
sudo freedb deploy myapp --image ecr:myapp:v1.2.3 --dry-run
```

### Features
- Zero-downtime blue-green deployment (same flow as TUI update)
- `incus init` → set env vars → `incus start` (env vars available on boot)
- File-based deploy lock with 30s timeout and stale lock cleanup
- JSON output for CI/CD parsing
- Dry-run mode
- Exit codes: 0=success, 1=error, 2=app not found, 3=lock timeout

### Example CI/CD (GitHub Actions)
```yaml
- name: Deploy to FreeDB
  run: |
    ssh -i ${{ secrets.SSH_KEY }} user@host \
      "sudo freedb deploy myapp --image ecr:myapp:${{ github.sha }} --json"
```

## Tested

- [x] Build and cross-compile clean
- [x] All unit tests pass
- [x] --help output correct
- [x] --dry-run shows expected plan


🤖 Generated with [Claude Code](https://claude.com/claude-code)