### PR TITLE
Add option to skip Traefik routing when adding an app

### DIFF
--- a/tui/internal/tui/addapp/model.go
+++ b/tui/internal/tui/addapp/model.go
@@ -25,6 +25,7 @@ type step int
 const (
 	stepName step = iota
 	stepImage
+	stepExpose
 	stepDomain
 	stepPort
 	stepTLS
@@ -43,6 +44,7 @@ type deployResult struct {
 type Model struct {
 	step        step
 	inputs      []textinput.Model
+	needsRoute  bool
 	needsDB     bool
 	tls         bool
 	envVars     []string // accumulated KEY=VALUE entries
@@ -117,6 +119,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "y", "n":
+			if m.step == stepExpose {
+				m.needsRoute = msg.String() == "y"
+				if m.needsRoute {
+					m.step = stepDomain
+					m.inputs[2].Focus()
+				} else {
+					m.step = stepDB
+				}
+				return m, nil
+			}
 			if m.step == stepTLS {
 				m.tls = msg.String() == "y"
 				m.step = stepDB
@@ -150,12 +162,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.step <= stepPort || m.step == stepDBEnvVar {
+	if m.step == stepName || m.step == stepImage || m.step == stepDomain || m.step == stepPort || m.step == stepDBEnvVar {
 		var cmd tea.Cmd
-		idx := int(m.step)
-		if m.step == stepDBEnvVar {
-			idx = 4
-		}
+		idx := map[step]int{
+			stepName: 0, stepImage: 1, stepDomain: 2, stepPort: 3, stepDBEnvVar: 4,
+		}[m.step]
 		m.inputs[idx], cmd = m.inputs[idx].Update(msg)
 		return m, cmd
 	}
@@ -191,8 +202,7 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.err = nil
-		m.step = stepDomain
-		m.inputs[2].Focus()
+		m.step = stepExpose
 		return m, nil
 
 	case stepDomain:
@@ -259,41 +269,59 @@ func (m Model) View() string {
 	b.WriteString(titleStyle.Render("Add App"))
 	b.WriteString("\n\n")
 
-	labels := []string{"App name:", "Image:", "Domain:", "App port:"}
-	hints := []string{
-		"",
-		"",
-		"",
-		"(port your app listens on inside the container)",
+	// Name
+	if m.step > stepName {
+		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("App name:"), m.inputs[0].Value()))
+	} else if m.step == stepName {
+		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("App name:"), m.inputs[0].View()))
 	}
 
-	for i, label := range labels {
-		if m.step > step(i) {
-			val := m.inputs[i].Value()
-			hint := ""
-			if i == 3 {
-				hint = "  " + dimStyle.Render(hints[i])
+	// Image
+	if m.step > stepImage {
+		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Image:"), m.inputs[1].Value()))
+	} else if m.step == stepImage {
+		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Image:"), m.inputs[1].View()))
+	}
+
+	// Expose via Traefik
+	if m.step >= stepExpose && m.step < stepDeploying {
+		if m.step == stepExpose {
+			b.WriteString(fmt.Sprintf("\n  %s [y/n] ", labelStyle.Render("Expose via Traefik?")))
+		} else {
+			expStr := "no"
+			if m.needsRoute {
+				expStr = "yes"
 			}
-			b.WriteString(fmt.Sprintf("  %s %s%s\n", labelStyle.Render(label), val, hint))
-		} else if m.step == step(i) {
-			hint := ""
-			if hints[i] != "" {
-				hint = "  " + dimStyle.Render(hints[i])
-			}
-			b.WriteString(fmt.Sprintf("  %s %s%s\n", labelStyle.Render(label), m.inputs[i].View(), hint))
+			b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Expose:"), expStr))
 		}
 	}
 
-	// TLS option
-	if m.step >= stepTLS && m.step < stepDeploying {
-		if m.step == stepTLS {
-			b.WriteString(fmt.Sprintf("\n  %s [y/n] ", labelStyle.Render("TLS (Let's Encrypt):")))
-		} else {
-			tlsStr := "yes (Let's Encrypt)"
-			if !m.tls {
-				tlsStr = "no (HTTP only)"
+	// Domain, Port, TLS — only if exposed
+	if m.needsRoute {
+		if m.step > stepDomain {
+			b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Domain:"), m.inputs[2].Value()))
+		} else if m.step == stepDomain {
+			b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Domain:"), m.inputs[2].View()))
+		}
+
+		portHint := "  " + dimStyle.Render("(port your app listens on inside the container)")
+		if m.step > stepPort {
+			b.WriteString(fmt.Sprintf("  %s %s%s\n", labelStyle.Render("App port:"), m.inputs[3].Value(), portHint))
+		} else if m.step == stepPort {
+			b.WriteString(fmt.Sprintf("  %s %s%s\n", labelStyle.Render("App port:"), m.inputs[3].View(), portHint))
+		}
+
+		// TLS option
+		if m.step >= stepTLS && m.step < stepDeploying {
+			if m.step == stepTLS {
+				b.WriteString(fmt.Sprintf("\n  %s [y/n] ", labelStyle.Render("TLS (Let's Encrypt):")))
+			} else {
+				tlsStr := "yes (Let's Encrypt)"
+				if !m.tls {
+					tlsStr = "no (HTTP only)"
+				}
+				b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("TLS:"), tlsStr))
 			}
-			b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("TLS:"), tlsStr))
 		}
 	}
 
@@ -336,11 +364,15 @@ func (m Model) View() string {
 
 	// External access summary
 	if m.step == stepConfirm {
-		domain := m.inputs[2].Value()
-		if m.tls {
-			b.WriteString(dimStyle.Render(fmt.Sprintf("\n  External: https://%s (port 443, TLS via Let's Encrypt)", domain)))
+		if m.needsRoute {
+			domain := m.inputs[2].Value()
+			if m.tls {
+				b.WriteString(dimStyle.Render(fmt.Sprintf("\n  External: https://%s (port 443, TLS via Let's Encrypt)", domain)))
+			} else {
+				b.WriteString(dimStyle.Render(fmt.Sprintf("\n  External: http://%s (port 80, no TLS)", domain)))
+			}
 		} else {
-			b.WriteString(dimStyle.Render(fmt.Sprintf("\n  External: http://%s (port 80, no TLS)", domain)))
+			b.WriteString(dimStyle.Render("\n  Internal only — no external routing"))
 		}
 		b.WriteString("\n\n  Press [enter] to deploy, [esc] to cancel\n")
 	}
@@ -354,11 +386,13 @@ func (m Model) View() string {
 			b.WriteString("\n" + errStyle.Render(fmt.Sprintf("  Deploy failed: %v", m.err)) + "\n")
 		} else {
 			b.WriteString("\n" + successStyle.Render("  "+m.deployMsg) + "\n")
-			domain := m.inputs[2].Value()
-			if m.tls {
-				b.WriteString(dimStyle.Render(fmt.Sprintf("  Access at: https://%s", domain)) + "\n")
-			} else {
-				b.WriteString(dimStyle.Render(fmt.Sprintf("  Access at: http://%s", domain)) + "\n")
+			if m.needsRoute {
+				domain := m.inputs[2].Value()
+				if m.tls {
+					b.WriteString(dimStyle.Render(fmt.Sprintf("  Access at: https://%s", domain)) + "\n")
+				} else {
+					b.WriteString(dimStyle.Render(fmt.Sprintf("  Access at: http://%s", domain)) + "\n")
+				}
 			}
 		}
 		b.WriteString(dimStyle.Render("\n  Press any key to return to dashboard"))
@@ -381,6 +415,7 @@ func (m Model) deploy() tea.Cmd {
 	image := strings.TrimSpace(m.inputs[1].Value())
 	domain := strings.TrimSpace(m.inputs[2].Value())
 	portStr := strings.TrimSpace(m.inputs[3].Value())
+	needsRoute := m.needsRoute
 	needsDB := m.needsDB
 	dbEnvVar := strings.TrimSpace(m.inputs[4].Value())
 	if dbEnvVar == "" {
@@ -474,9 +509,11 @@ func (m Model) deploy() tea.Cmd {
 			return deployResult{err: fmt.Errorf("waiting for IP: %w", err)}
 		}
 
-		// 6. Create Traefik route
-		if err := traefik.PushRoute(ic, name, domain, ip, port, tls); err != nil {
-			return deployResult{err: fmt.Errorf("creating route: %w", err)}
+		// 6. Create Traefik route (skip for internal-only containers)
+		if needsRoute {
+			if err := traefik.PushRoute(ic, name, domain, ip, port, tls); err != nil {
+				return deployResult{err: fmt.Errorf("creating route: %w", err)}
+			}
 		}
 
 		// Save to registry

--- a/tui/internal/tui/addapp/model_test.go
+++ b/tui/internal/tui/addapp/model_test.go
@@ -1,0 +1,445 @@
+package addapp
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/danbiagini/freedb-tui/internal/registry"
+)
+
+// key sends a KeyMsg to the model and returns the updated model.
+func key(m Model, k string) Model {
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)})
+	return updated.(Model)
+}
+
+func enter(m Model) Model {
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	return updated.(Model)
+}
+
+func esc(m Model) Model {
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	return updated.(Model)
+}
+
+// typeText sends each character as a key event, simulating user typing.
+func typeText(m Model, text string) Model {
+	for _, ch := range text {
+		m = key(m, string(ch))
+	}
+	return m
+}
+
+// newTestModel creates a Model suitable for step-transition testing.
+func newTestModel(t *testing.T) Model {
+	t.Helper()
+	reg, _ := registry.Load(filepath.Join(t.TempDir(), "reg.json"))
+	return NewModel(nil, reg, nil)
+}
+
+// advancePastName types a valid name and presses enter.
+func advancePastName(m Model) Model {
+	m = typeText(m, "myapp")
+	return enter(m)
+}
+
+// advancePastImage types an image and presses enter.
+func advancePastImage(m Model, image string) Model {
+	m = typeText(m, image)
+	return enter(m)
+}
+
+func TestInitialStep(t *testing.T) {
+	m := newTestModel(t)
+	if m.step != stepName {
+		t.Fatalf("expected stepName, got %d", m.step)
+	}
+}
+
+func TestNameValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid", "myapp", false},
+		{"with hyphens", "my-app", false},
+		{"starts with number", "1app", true},
+		{"uppercase", "MyApp", true},
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModel(t)
+			m = typeText(m, tt.input)
+			m = enter(m)
+
+			if tt.wantErr {
+				if m.err == nil {
+					t.Error("expected validation error")
+				}
+				if m.step != stepName {
+					t.Errorf("expected to stay on stepName, got %d", m.step)
+				}
+			} else {
+				if m.err != nil {
+					t.Errorf("unexpected error: %v", m.err)
+				}
+				if m.step != stepImage {
+					t.Errorf("expected stepImage, got %d", m.step)
+				}
+			}
+		})
+	}
+}
+
+func TestImageRequired(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = enter(m) // empty image
+
+	if m.err == nil {
+		t.Error("expected error for empty image")
+	}
+	if m.step != stepImage {
+		t.Errorf("expected stepImage, got %d", m.step)
+	}
+}
+
+func TestImageAdvancesToExpose(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/traefik/whoami")
+
+	if m.step != stepExpose {
+		t.Fatalf("expected stepExpose, got %d", m.step)
+	}
+}
+
+// Full flow: OCI image, with Traefik, with TLS, with DB
+func TestFlow_OCI_Traefik_TLS_DB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/traefik/whoami")
+
+	// Expose via Traefik: yes
+	if m.step != stepExpose {
+		t.Fatalf("expected stepExpose, got %d", m.step)
+	}
+	m = key(m, "y")
+
+	// Domain
+	if m.step != stepDomain {
+		t.Fatalf("expected stepDomain, got %d", m.step)
+	}
+	m = typeText(m, "myapp.example.com")
+	m = enter(m)
+
+	// Port
+	if m.step != stepPort {
+		t.Fatalf("expected stepPort, got %d", m.step)
+	}
+	m = enter(m) // accept default 8080
+
+	// TLS
+	if m.step != stepTLS {
+		t.Fatalf("expected stepTLS, got %d", m.step)
+	}
+	m = key(m, "y")
+
+	// DB
+	if m.step != stepDB {
+		t.Fatalf("expected stepDB, got %d", m.step)
+	}
+	m = key(m, "y")
+
+	// DB env var
+	if m.step != stepDBEnvVar {
+		t.Fatalf("expected stepDBEnvVar, got %d", m.step)
+	}
+	m = enter(m) // accept default DATABASE_URL
+
+	// Env vars — empty to finish
+	if m.step != stepEnvVars {
+		t.Fatalf("expected stepEnvVars, got %d", m.step)
+	}
+	m = enter(m)
+
+	// Confirm
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+
+	if !m.needsRoute {
+		t.Error("expected needsRoute=true")
+	}
+	if !m.tls {
+		t.Error("expected tls=true")
+	}
+	if !m.needsDB {
+		t.Error("expected needsDB=true")
+	}
+}
+
+// Full flow: OCI image, with Traefik, no TLS, no DB
+func TestFlow_OCI_Traefik_NoTLS_NoDB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/traefik/whoami")
+
+	m = key(m, "y") // expose: yes
+	m = typeText(m, "myapp.example.com")
+	m = enter(m)    // domain
+	m = enter(m)    // port (default)
+	m = key(m, "n") // TLS: no
+	m = key(m, "n") // DB: no
+	m = enter(m)    // env vars: done
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if !m.needsRoute {
+		t.Error("expected needsRoute=true")
+	}
+	if m.tls {
+		t.Error("expected tls=false")
+	}
+	if m.needsDB {
+		t.Error("expected needsDB=false")
+	}
+}
+
+// Full flow: OCI image, no Traefik, with DB
+func TestFlow_OCI_NoTraefik_DB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/library/redis")
+
+	// Expose: no — should skip domain/port/TLS
+	m = key(m, "n")
+
+	if m.step != stepDB {
+		t.Fatalf("expected stepDB after declining expose, got %d", m.step)
+	}
+	m = key(m, "y") // DB: yes
+
+	if m.step != stepDBEnvVar {
+		t.Fatalf("expected stepDBEnvVar, got %d", m.step)
+	}
+	m = enter(m) // accept default
+
+	if m.step != stepEnvVars {
+		t.Fatalf("expected stepEnvVars, got %d", m.step)
+	}
+	m = enter(m) // done
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if m.needsRoute {
+		t.Error("expected needsRoute=false")
+	}
+	if !m.needsDB {
+		t.Error("expected needsDB=true")
+	}
+}
+
+// Full flow: OCI image, no Traefik, no DB
+func TestFlow_OCI_NoTraefik_NoDB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/library/redis")
+
+	m = key(m, "n") // expose: no
+	m = key(m, "n") // DB: no
+	m = enter(m)    // env vars: done
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if m.needsRoute {
+		t.Error("expected needsRoute=false")
+	}
+	if m.needsDB {
+		t.Error("expected needsDB=false")
+	}
+}
+
+// Full flow: System container, with Traefik, with DB
+func TestFlow_System_Traefik_DB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "ubuntu/24.04/cloud")
+
+	m = key(m, "y") // expose: yes
+
+	if m.step != stepDomain {
+		t.Fatalf("expected stepDomain, got %d", m.step)
+	}
+	m = typeText(m, "sys.example.com")
+	m = enter(m)    // domain
+	m = enter(m)    // port (default)
+	m = key(m, "y") // TLS: yes
+	m = key(m, "y") // DB: yes
+	m = enter(m)    // DB env var (default)
+	m = enter(m)    // env vars: done
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if !m.needsRoute {
+		t.Error("expected needsRoute=true")
+	}
+	if !m.needsDB {
+		t.Error("expected needsDB=true")
+	}
+}
+
+// Full flow: System container, no Traefik, no DB
+func TestFlow_System_NoTraefik_NoDB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "debian/12/cloud")
+
+	m = key(m, "n") // expose: no
+	m = key(m, "n") // DB: no
+	m = enter(m)    // env vars: done
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if m.needsRoute {
+		t.Error("expected needsRoute=false")
+	}
+	if m.needsDB {
+		t.Error("expected needsDB=false")
+	}
+}
+
+// Full flow: System container, no Traefik, with DB
+func TestFlow_System_NoTraefik_DB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "ubuntu/24.04/cloud")
+
+	m = key(m, "n") // expose: no
+	m = key(m, "y") // DB: yes
+	m = enter(m)    // DB env var (default)
+	m = enter(m)    // env vars: done
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if m.needsRoute {
+		t.Error("expected needsRoute=false")
+	}
+	if !m.needsDB {
+		t.Error("expected needsDB=true")
+	}
+}
+
+// Full flow: System container, with Traefik, no DB
+func TestFlow_System_Traefik_NoDB(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "debian/12/cloud")
+
+	m = key(m, "y") // expose: yes
+	m = typeText(m, "sys.example.com")
+	m = enter(m)    // domain
+	m = enter(m)    // port (default)
+	m = key(m, "n") // TLS: no
+	m = key(m, "n") // DB: no
+	m = enter(m)    // env vars: done
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if !m.needsRoute {
+		t.Error("expected needsRoute=true")
+	}
+	if m.tls {
+		t.Error("expected tls=false")
+	}
+	if m.needsDB {
+		t.Error("expected needsDB=false")
+	}
+}
+
+func TestEnvVarsAccumulate(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/library/nginx")
+	m = key(m, "n") // expose: no
+	m = key(m, "n") // DB: no
+
+	// Add two env vars
+	m = typeText(m, "FOO=bar")
+	m = enter(m)
+	m = typeText(m, "BAZ=qux")
+	m = enter(m)
+	m = enter(m) // empty to finish
+
+	if m.step != stepConfirm {
+		t.Fatalf("expected stepConfirm, got %d", m.step)
+	}
+	if len(m.envVars) != 2 {
+		t.Fatalf("expected 2 env vars, got %d", len(m.envVars))
+	}
+	if m.envVars[0] != "FOO=bar" {
+		t.Errorf("expected FOO=bar, got %s", m.envVars[0])
+	}
+	if m.envVars[1] != "BAZ=qux" {
+		t.Errorf("expected BAZ=qux, got %s", m.envVars[1])
+	}
+}
+
+func TestEnvVarValidation(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/library/nginx")
+	m = key(m, "n") // expose: no
+	m = key(m, "n") // DB: no
+
+	// Invalid format (no =)
+	m = typeText(m, "INVALID")
+	m = enter(m)
+
+	if m.err == nil {
+		t.Error("expected error for invalid env var format")
+	}
+	if m.step != stepEnvVars {
+		t.Errorf("expected to stay on stepEnvVars, got %d", m.step)
+	}
+}
+
+func TestEscCancels(t *testing.T) {
+	m := newTestModel(t)
+	m = esc(m)
+
+	if !m.cancelled {
+		t.Error("expected cancelled=true")
+	}
+	if !m.done {
+		t.Error("expected done=true")
+	}
+}
+
+func TestDomainRequired(t *testing.T) {
+	m := newTestModel(t)
+	m = advancePastName(m)
+	m = advancePastImage(m, "docker.io/traefik/whoami")
+	m = key(m, "y") // expose: yes
+	m = enter(m)    // empty domain
+
+	if m.err == nil {
+		t.Error("expected error for empty domain")
+	}
+	if m.step != stepDomain {
+		t.Errorf("expected to stay on stepDomain, got %d", m.step)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds "Expose via Traefik? [y/n]" prompt after image selection
- Answering "n" skips domain, port, and TLS steps — creates an internal-only container
- Useful for system containers, background workers, or services without direct web access
- Unit tests covering all 8 combinations of the creation matrix (OCI/system x Traefik/no x DB/no)

Closes #40

## Test plan

- [x] Tested on AWS test instance — created system container without Traefik routing
- [x] 15 unit tests passing (`go test ./internal/tui/addapp/`)
- [x] Verify existing OCI app creation with Traefik still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)