### PR TITLE
Add GitHub Releases for automated binary distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
         run: go test ./...
 
       - name: Build (linux/amd64)
-        run: GOOS=linux GOARCH=amd64 go build -o /dev/null .
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$VERSION" -o /dev/null .
 
   shellcheck:
     name: Shell Script Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,14 @@ jobs:
         with:
           go-version-file: tui/go.mod
 
-      - name: Go vet
-        run: go vet ./...
+      - name: Vet
+        run: make vet
 
-      - name: Go test
-        run: go test ./...
+      - name: Test
+        run: make test
 
       - name: Build (linux/amd64)
-        run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
-          GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$VERSION" -o /dev/null .
+        run: make build-linux
 
   shellcheck:
     name: Shell Script Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,12 @@ jobs:
           go-version-file: tui/go.mod
 
       - name: Build
-        run: |
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build \
-            -ldflags "-s -w -X main.version=${{ github.ref_name }}" \
-            -o freedb-${{ matrix.goos }}-${{ matrix.goarch }} .
+        run: make build-cross GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} VERSION=${{ github.ref_name }}
 
       - uses: actions/upload-artifact@v4
         with:
           name: freedb-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: tui/freedb-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: tui/build/freedb-${{ matrix.goos }}-${{ matrix.goarch }}
 
   release:
     name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: arm64
+    defaults:
+      run:
+        working-directory: tui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: tui/go.mod
+
+      - name: Build
+        run: |
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build \
+            -ldflags "-s -w -X main.version=${{ github.ref_name }}" \
+            -o freedb-${{ matrix.goos }}-${{ matrix.goarch }} .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: freedb-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: tui/freedb-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release
+          for dir in artifacts/freedb-*; do
+            name=$(basename "$dir")
+            cp "$dir/$name" "release/$name"
+            chmod +x "release/$name"
+          done
+          cd release && sha256sum freedb-* > checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: release/*

--- a/tui/Makefile
+++ b/tui/Makefile
@@ -3,13 +3,16 @@ BUILD_DIR = build
 VERSION = $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS = -ldflags "-X main.version=$(VERSION)"
 
-.PHONY: build build-linux clean tidy test vet release
+.PHONY: build build-linux build-cross clean tidy test vet release
 
 build:
 	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY) .
 
 build-linux:
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY)-linux-amd64 .
+
+build-cross:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-s -w -X main.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY)-$(GOOS)-$(GOARCH) .
 
 clean:
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
## Summary

- Adds `release.yml` workflow triggered on tag push (`v*`)
- Builds `freedb` binary for linux/amd64, linux/arm64, and darwin/arm64
- Embeds version via `-ldflags -X main.version=<tag>`
- Creates GitHub Release with binaries and SHA256 checksums
- Uses `softprops/action-gh-release` with auto-generated release notes
- Also updates CI to embed version in test builds

## Usage

After merge, tagging a release will trigger automated builds:
```bash
git tag -a v0.5 -m "v0.5"
git push origin v0.5
```

Binaries will appear at `github.com/danbiagini/FreeDB/releases`

Closes #19

## Test plan

- [ ] Merge and push a test tag to verify workflow runs
- [ ] Verify binaries are downloadable and `--version` shows correct tag
- [ ] Verify checksums match

🤖 Generated with [Claude Code](https://claude.com/claude-code)