### PR TITLE
Align Go module name with GitHub repo

### DIFF
--- a/tui/go.mod
+++ b/tui/go.mod
@@ -1,4 +1,4 @@
-module github.com/danbiagini/freedb-tui
+module github.com/danbiagini/FreeDB/tui
 
 go 1.26.1
 

--- a/tui/internal/check/check.go
+++ b/tui/internal/check/check.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/danbiagini/freedb-tui/internal/config"
-	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/config"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
 )
 
 type Result struct {

--- a/tui/internal/db/postgres.go
+++ b/tui/internal/db/postgres.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
 )
 
 const dbContainer = "db1"

--- a/tui/internal/deploy/deploy.go
+++ b/tui/internal/deploy/deploy.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/danbiagini/freedb-tui/internal/incus"
-	"github.com/danbiagini/freedb-tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
 )
 
 type Result struct {

--- a/tui/internal/deploy/deploy_test.go
+++ b/tui/internal/deploy/deploy_test.go
@@ -3,7 +3,7 @@ package deploy
 import (
 	"testing"
 
-	"github.com/danbiagini/freedb-tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
 )
 
 func TestResolveImage(t *testing.T) {

--- a/tui/internal/deploy/engine.go
+++ b/tui/internal/deploy/engine.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/danbiagini/freedb-tui/internal/incus"
-	"github.com/danbiagini/freedb-tui/internal/registry"
-	"github.com/danbiagini/freedb-tui/internal/traefik"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/traefik"
 )
 
 // UpdateParams contains everything needed to perform a zero-downtime update

--- a/tui/internal/traefik/metrics.go
+++ b/tui/internal/traefik/metrics.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
 )
 
 // ServiceMetrics holds per-service traffic stats from Traefik Prometheus metrics

--- a/tui/internal/traefik/routes.go
+++ b/tui/internal/traefik/routes.go
@@ -3,7 +3,7 @@ package traefik
 import (
 	"fmt"
 
-	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
 )
 
 const proxyContainer = "proxy1"

--- a/tui/internal/tui/addapp/model.go
+++ b/tui/internal/tui/addapp/model.go
@@ -11,11 +11,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/danbiagini/freedb-tui/internal/config"
-	"github.com/danbiagini/freedb-tui/internal/db"
-	"github.com/danbiagini/freedb-tui/internal/incus"
-	"github.com/danbiagini/freedb-tui/internal/registry"
-	"github.com/danbiagini/freedb-tui/internal/traefik"
+	"github.com/danbiagini/FreeDB/tui/internal/config"
+	"github.com/danbiagini/FreeDB/tui/internal/db"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/traefik"
 )
 
 var nameRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)

--- a/tui/internal/tui/addapp/model_test.go
+++ b/tui/internal/tui/addapp/model_test.go
@@ -6,7 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/danbiagini/freedb-tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
 )
 
 // key sends a KeyMsg to the model and returns the updated model.

--- a/tui/internal/tui/dashboard/model.go
+++ b/tui/internal/tui/dashboard/model.go
@@ -11,10 +11,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/danbiagini/freedb-tui/internal/config"
-	"github.com/danbiagini/freedb-tui/internal/incus"
-	"github.com/danbiagini/freedb-tui/internal/registry"
-	"github.com/danbiagini/freedb-tui/internal/traefik"
+	"github.com/danbiagini/FreeDB/tui/internal/config"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/traefik"
 )
 
 var (

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -11,8 +11,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/danbiagini/freedb-tui/internal/db"
-	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/db"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
 )
 
 type subview int

--- a/tui/internal/tui/manage/model.go
+++ b/tui/internal/tui/manage/model.go
@@ -13,11 +13,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/danbiagini/freedb-tui/internal/db"
-	"github.com/danbiagini/freedb-tui/internal/deploy"
-	"github.com/danbiagini/freedb-tui/internal/incus"
-	"github.com/danbiagini/freedb-tui/internal/registry"
-	"github.com/danbiagini/freedb-tui/internal/traefik"
+	"github.com/danbiagini/FreeDB/tui/internal/db"
+	"github.com/danbiagini/FreeDB/tui/internal/deploy"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/traefik"
 )
 
 type subview int

--- a/tui/internal/tui/model.go
+++ b/tui/internal/tui/model.go
@@ -3,14 +3,14 @@ package tui
 import (
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/danbiagini/freedb-tui/internal/config"
-	"github.com/danbiagini/freedb-tui/internal/incus"
-	"github.com/danbiagini/freedb-tui/internal/registry"
-	"github.com/danbiagini/freedb-tui/internal/tui/addapp"
-	"github.com/danbiagini/freedb-tui/internal/tui/dashboard"
-	"github.com/danbiagini/freedb-tui/internal/tui/databases"
-	"github.com/danbiagini/freedb-tui/internal/tui/manage"
-	"github.com/danbiagini/freedb-tui/internal/tui/remotes"
+	"github.com/danbiagini/FreeDB/tui/internal/config"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/tui/addapp"
+	"github.com/danbiagini/FreeDB/tui/internal/tui/dashboard"
+	"github.com/danbiagini/FreeDB/tui/internal/tui/databases"
+	"github.com/danbiagini/FreeDB/tui/internal/tui/manage"
+	"github.com/danbiagini/FreeDB/tui/internal/tui/remotes"
 )
 
 type view int

--- a/tui/internal/tui/remotes/model.go
+++ b/tui/internal/tui/remotes/model.go
@@ -8,7 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/danbiagini/freedb-tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
 )
 
 type subview int

--- a/tui/main.go
+++ b/tui/main.go
@@ -10,15 +10,15 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/danbiagini/freedb-tui/internal/check"
-	"github.com/danbiagini/freedb-tui/internal/config"
-	"github.com/danbiagini/freedb-tui/internal/db"
-	"github.com/danbiagini/freedb-tui/internal/deploy"
-	"github.com/danbiagini/freedb-tui/internal/incus"
-	"github.com/danbiagini/freedb-tui/internal/registry"
-	"github.com/danbiagini/freedb-tui/internal/traefik"
-	"github.com/danbiagini/freedb-tui/internal/tui"
-	"github.com/danbiagini/freedb-tui/internal/upgrade"
+	"github.com/danbiagini/FreeDB/tui/internal/check"
+	"github.com/danbiagini/FreeDB/tui/internal/config"
+	"github.com/danbiagini/FreeDB/tui/internal/db"
+	"github.com/danbiagini/FreeDB/tui/internal/deploy"
+	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
+	"github.com/danbiagini/FreeDB/tui/internal/traefik"
+	"github.com/danbiagini/FreeDB/tui/internal/tui"
+	"github.com/danbiagini/FreeDB/tui/internal/upgrade"
 )
 
 var version = "dev"


### PR DESCRIPTION
## Summary

Renames Go module from `github.com/danbiagini/freedb-tui` to `github.com/danbiagini/FreeDB/tui` so the module path matches the actual GitHub repo. This enables `go install github.com/danbiagini/FreeDB/tui@latest`.

Closes #42

## Test plan

- [x] `go build ./...` passes
- [x] All tests pass
- [ ] Verify CI passes with new module name

🤖 Generated with [Claude Code](https://claude.com/claude-code)