### PR TITLE
Switch to per-database backups with individual files

### DIFF
--- a/ops/backup-db.sh
+++ b/ops/backup-db.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 # FreeDB database backup script
 # Runs on the HOST, not inside the db1 container.
-# Uses incus exec to run pg_dumpall/pg_dump inside db1 and pipes output to the host.
+# Uses incus exec to run pg_dump inside db1 and pipes output to the host.
 # Writes status to /var/lib/freedb/backup-status.json for TUI display.
 #
-# PARAMETERS
-#   $1 - database name (optional — if omitted, runs pg_dumpall for full backup)
+# MODES
+#   No args    — back up all non-system databases + roles
+#   $1 = name  — back up a single database
 #
 # ENVIRONMENT
 #   FREEDB_BACKUP_BUCKET - cloud storage bucket name (default: freedb-backup)
@@ -19,91 +20,132 @@ BACKUP_BUCKET="${FREEDB_BACKUP_BUCKET:-freedb-backup}"
 DB_CONTAINER="${FREEDB_DB_CONTAINER:-db1}"
 CURRENT_DATE=$(date "+%Y%m%d")
 HOSTNAME=$(hostname)
-DB_NAME="${1:-pg_dumpall}"
 START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Ensure backup directory exists
 mkdir -p "$BACKUP_DIRECTORY"
 
+# Upload a file to cloud storage. Sets CLOUD_STATUS and CLOUD_ERROR.
+upload_to_cloud() {
+  local file="$1"
+  local name
+  name=$(basename "$file")
+  CLOUD_STATUS="none"
+  CLOUD_ERROR=""
+
+  if command -v gcloud &>/dev/null; then
+    if gcloud storage cp "$file" "gs://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+      CLOUD_STATUS="uploaded"
+    else
+      CLOUD_STATUS="failed"
+      CLOUD_ERROR="gcloud upload failed"
+    fi
+  elif command -v aws &>/dev/null; then
+    if aws s3 cp "$file" "s3://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+      CLOUD_STATUS="uploaded"
+    else
+      CLOUD_STATUS="failed"
+      CLOUD_ERROR="aws s3 upload failed"
+    fi
+  else
+    CLOUD_STATUS="skipped"
+    CLOUD_ERROR="no cloud CLI found"
+  fi
+}
+
+# Back up a single database (or roles). Appends result to RESULTS array.
+backup_one() {
+  local db_name="$1"
+  local dump_cmd="$2"
+  local fileName="${db_name}_${CURRENT_DATE}.sql.gz"
+  local status="success"
+  local cloud_status="none"
+  local cloud_error=""
+  local file_size=0
+
+  echo -n "Backing up ${db_name}... "
+
+  if ! sudo incus exec "$DB_CONTAINER" -- $dump_cmd | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
+    echo "FAILED"
+    RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"failed\",\"file\":\"${fileName}\",\"size_bytes\":0,\"cloud_upload\":\"none\",\"error\":\"dump failed\"}")
+    return 1
+  fi
+
+  if [ ! -s "$BACKUP_DIRECTORY/$fileName" ]; then
+    echo "FAILED (empty)"
+    RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"failed\",\"file\":\"${fileName}\",\"size_bytes\":0,\"cloud_upload\":\"none\",\"error\":\"backup file empty\"}")
+    return 1
+  fi
+
+  file_size=$(stat -c%s "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || stat -f%z "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || echo "0")
+
+  upload_to_cloud "$BACKUP_DIRECTORY/$fileName"
+  cloud_status="$CLOUD_STATUS"
+  cloud_error="$CLOUD_ERROR"
+
+  local size_human
+  size_human=$(du -h "$BACKUP_DIRECTORY/$fileName" | cut -f1)
+  echo "OK (${size_human}, ${cloud_status})"
+
+  RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"success\",\"file\":\"${fileName}\",\"size_bytes\":${file_size},\"cloud_upload\":\"${cloud_status}\",\"error\":\"${cloud_error}\"}")
+  return 0
+}
+
+# Write status file from RESULTS array
 write_status() {
-  local status="$1"
-  local file="${2:-}"
-  local size="${3:-}"
-  local cloud="${4:-}"
-  local error="${5:-}"
+  local entries=""
+  for i in "${!RESULTS[@]}"; do
+    if [ "$i" -gt 0 ]; then
+      entries="${entries},"
+    fi
+    entries="${entries}
+    ${RESULTS[$i]}"
+  done
 
   cat > "$STATUS_FILE" << STATUSEOF
 {
-  "database": "${DB_NAME}",
-  "status": "${status}",
   "timestamp": "${START_TIME}",
-  "file": "${file}",
-  "size_bytes": ${size:-0},
-  "cloud_upload": "${cloud}",
-  "error": "${error}",
-  "bucket": "${BACKUP_BUCKET}"
+  "bucket": "${BACKUP_BUCKET}",
+  "databases": [${entries}
+  ]
 }
 STATUSEOF
 }
 
-# Run the dump inside db1, pipe to host
-if [ -z "${1:-}" ]; then
-  # Full backup using pg_dumpall (includes users/roles)
-  fileName="pg_dumpall_${CURRENT_DATE}.sql.gz"
-  if ! sudo incus exec "$DB_CONTAINER" -- sudo -u postgres pg_dumpall | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
-    write_status "failed" "$fileName" "0" "none" "pg_dumpall failed"
-    echo "Backup failed: pg_dumpall error"
-    exit 1
-  fi
+# Collect results
+RESULTS=()
+FAILURES=0
+
+if [ -n "${1:-}" ]; then
+  # Single database mode
+  backup_one "$1" "sudo -u postgres pg_dump $1" || FAILURES=$((FAILURES + 1))
 else
-  # Single database backup
-  fileName="${1}_${CURRENT_DATE}.sql.gz"
-  if ! sudo incus exec "$DB_CONTAINER" -- sudo -u postgres pg_dump "$1" | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
-    write_status "failed" "$fileName" "0" "none" "pg_dump failed for $1"
-    echo "Backup failed: pg_dump error for $1"
-    exit 1
-  fi
-fi
+  # Full backup mode: roles + all user databases
 
-# Verify the backup was created
-if [ ! -f "$BACKUP_DIRECTORY/$fileName" ] || [ ! -s "$BACKUP_DIRECTORY/$fileName" ]; then
-  write_status "failed" "$fileName" "0" "none" "backup file missing or empty"
-  echo "Backup failed: $fileName is missing or empty"
-  exit 1
-fi
+  # 1. Dump roles (users/passwords)
+  backup_one "roles" "sudo -u postgres pg_dumpall --roles-only" || FAILURES=$((FAILURES + 1))
 
-FILE_SIZE=$(stat -c%s "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || stat -f%z "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || echo "0")
-echo "Backup created: $BACKUP_DIRECTORY/$fileName ($(du -h "$BACKUP_DIRECTORY/$fileName" | cut -f1))"
+  # 2. List non-system databases and back up each
+  DB_LIST=$(sudo incus exec "$DB_CONTAINER" -- sudo -u postgres psql -At -c \
+    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres')" 2>/dev/null || echo "")
 
-# Upload to cloud storage using the host's cloud CLI
-CLOUD_STATUS="none"
-CLOUD_ERROR=""
-if command -v gcloud &>/dev/null; then
-  if gcloud storage cp "$BACKUP_DIRECTORY/$fileName" "gs://${BACKUP_BUCKET}/${HOSTNAME}/$fileName" 2>/dev/null; then
-    CLOUD_STATUS="uploaded"
-    echo "Uploaded to gs://${BACKUP_BUCKET}/${HOSTNAME}/$fileName"
+  if [ -z "$DB_LIST" ]; then
+    echo "Warning: No user databases found"
   else
-    CLOUD_STATUS="failed"
-    CLOUD_ERROR="gcloud upload failed"
-    echo "Warning: Cloud upload failed"
+    while IFS= read -r db; do
+      [ -z "$db" ] && continue
+      backup_one "$db" "sudo -u postgres pg_dump $db" || FAILURES=$((FAILURES + 1))
+    done <<< "$DB_LIST"
   fi
-elif command -v aws &>/dev/null; then
-  if aws s3 cp "$BACKUP_DIRECTORY/$fileName" "s3://${BACKUP_BUCKET}/${HOSTNAME}/$fileName" 2>/dev/null; then
-    CLOUD_STATUS="uploaded"
-    echo "Uploaded to s3://${BACKUP_BUCKET}/${HOSTNAME}/$fileName"
-  else
-    CLOUD_STATUS="failed"
-    CLOUD_ERROR="aws s3 upload failed"
-    echo "Warning: Cloud upload failed"
-  fi
-else
-  CLOUD_STATUS="skipped"
-  CLOUD_ERROR="no cloud CLI found"
-  echo "Warning: No cloud CLI found — backup saved locally only"
 fi
 
-# Write final status
-write_status "success" "$fileName" "$FILE_SIZE" "$CLOUD_STATUS" "$CLOUD_ERROR"
+write_status
 
 # Delete local backups older than 30 days
 find "$BACKUP_DIRECTORY" -type f -name "*.sql.gz" -mtime +30 -delete
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "Backup completed with $FAILURES failure(s)"
+  exit 1
+fi
+
+echo "All backups completed successfully"

--- a/ops/backup-db.sh
+++ b/ops/backup-db.sh
@@ -31,20 +31,25 @@ upload_to_cloud() {
   name=$(basename "$file")
   CLOUD_STATUS="none"
   CLOUD_ERROR=""
+  CLOUD_URL=""
 
   if command -v gcloud &>/dev/null; then
-    if gcloud storage cp "$file" "gs://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+    CLOUD_URL="gs://${BACKUP_BUCKET}/${HOSTNAME}/$name"
+    if gcloud storage cp "$file" "$CLOUD_URL" 2>/dev/null; then
       CLOUD_STATUS="uploaded"
     else
       CLOUD_STATUS="failed"
       CLOUD_ERROR="gcloud upload failed"
+      CLOUD_URL=""
     fi
   elif command -v aws &>/dev/null; then
-    if aws s3 cp "$file" "s3://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+    CLOUD_URL="s3://${BACKUP_BUCKET}/${HOSTNAME}/$name"
+    if aws s3 cp "$file" "$CLOUD_URL" 2>/dev/null; then
       CLOUD_STATUS="uploaded"
     else
       CLOUD_STATUS="failed"
       CLOUD_ERROR="aws s3 upload failed"
+      CLOUD_URL=""
     fi
   else
     CLOUD_STATUS="skipped"
@@ -81,12 +86,13 @@ backup_one() {
   upload_to_cloud "$BACKUP_DIRECTORY/$fileName"
   cloud_status="$CLOUD_STATUS"
   cloud_error="$CLOUD_ERROR"
+  local cloud_url="$CLOUD_URL"
 
   local size_human
   size_human=$(du -h "$BACKUP_DIRECTORY/$fileName" | cut -f1)
   echo "OK (${size_human}, ${cloud_status})"
 
-  RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"success\",\"file\":\"${fileName}\",\"size_bytes\":${file_size},\"cloud_upload\":\"${cloud_status}\",\"error\":\"${cloud_error}\"}")
+  RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"success\",\"file\":\"${fileName}\",\"size_bytes\":${file_size},\"cloud_upload\":\"${cloud_status}\",\"cloud_url\":\"${cloud_url}\",\"error\":\"${cloud_error}\"}")
   return 0
 }
 

--- a/ops/backup-db.sh
+++ b/ops/backup-db.sh
@@ -64,7 +64,7 @@ backup_one() {
 
   echo -n "Backing up ${db_name}... "
 
-  if ! sudo incus exec "$DB_CONTAINER" -- $dump_cmd | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
+  if ! sudo incus exec "$DB_CONTAINER" -- $dump_cmd < /dev/null | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
     echo "FAILED"
     RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"failed\",\"file\":\"${fileName}\",\"size_bytes\":0,\"cloud_upload\":\"none\",\"error\":\"dump failed\"}")
     return 1

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -288,71 +288,91 @@ func (m Model) View() string {
 func getLastBackupInfo() string {
 	statusFile := "/var/lib/freedb/backup-status.json"
 	data, err := os.ReadFile(statusFile)
-	if err == nil {
-		var status struct {
+	if err != nil {
+		return "no backups found"
+	}
+
+	// Try new per-database format first
+	var multiStatus struct {
+		Timestamp string `json:"timestamp"`
+		Databases []struct {
 			Database    string `json:"database"`
 			Status      string `json:"status"`
-			Timestamp   string `json:"timestamp"`
 			File        string `json:"file"`
 			SizeBytes   int64  `json:"size_bytes"`
 			CloudUpload string `json:"cloud_upload"`
 			Error       string `json:"error"`
-		}
-		if json.Unmarshal(data, &status) == nil {
-			size := formatSize(status.SizeBytes)
-			cloud := status.CloudUpload
-			if cloud == "uploaded" {
-				cloud = "uploaded to cloud"
-			} else if cloud == "failed" {
-				cloud = "cloud upload FAILED"
-			} else if cloud == "skipped" {
-				cloud = "local only"
+		} `json:"databases"`
+	}
+	if json.Unmarshal(data, &multiStatus) == nil && len(multiStatus.Databases) > 0 {
+		succeeded := 0
+		failed := 0
+		var totalSize int64
+		cloudStatus := ""
+		for _, db := range multiStatus.Databases {
+			if db.Status == "success" {
+				succeeded++
+			} else {
+				failed++
 			}
-
-			result := fmt.Sprintf("%s — %s (%s, %s)", status.Status, status.File, size, cloud)
-			if status.Timestamp != "" {
-				result += " at " + status.Timestamp
+			totalSize += db.SizeBytes
+			if cloudStatus == "" {
+				cloudStatus = db.CloudUpload
+			} else if cloudStatus != db.CloudUpload {
+				cloudStatus = "mixed"
 			}
-			if status.Error != "" {
-				result += " [" + status.Error + "]"
-			}
-			return result
 		}
-	}
 
-	// Fallback: check backup directory for files
-	backupDir := "/var/lib/freedb/backups"
-	entries, err := os.ReadDir(backupDir)
-	if err != nil || len(entries) == 0 {
-		return "no backups found"
-	}
-
-	var newest os.DirEntry
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
+		cloud := cloudStatus
+		if cloud == "uploaded" {
+			cloud = "uploaded to cloud"
+		} else if cloud == "failed" {
+			cloud = "cloud upload FAILED"
+		} else if cloud == "skipped" {
+			cloud = "local only"
 		}
-		if newest == nil {
-			newest = e
-			continue
+
+		result := fmt.Sprintf("%d databases (%s, %s)", succeeded, formatSize(totalSize), cloud)
+		if failed > 0 {
+			result += fmt.Sprintf(" [%d failed]", failed)
 		}
-		ni, _ := newest.Info()
-		ei, _ := e.Info()
-		if ni != nil && ei != nil && ei.ModTime().After(ni.ModTime()) {
-			newest = e
+		if multiStatus.Timestamp != "" {
+			result += " at " + multiStatus.Timestamp
 		}
+		return result
 	}
 
-	if newest == nil {
-		return "no backups found"
+	// Fallback: old single-database format
+	var singleStatus struct {
+		Status      string `json:"status"`
+		Timestamp   string `json:"timestamp"`
+		File        string `json:"file"`
+		SizeBytes   int64  `json:"size_bytes"`
+		CloudUpload string `json:"cloud_upload"`
+		Error       string `json:"error"`
+	}
+	if json.Unmarshal(data, &singleStatus) == nil && singleStatus.Status != "" {
+		size := formatSize(singleStatus.SizeBytes)
+		cloud := singleStatus.CloudUpload
+		if cloud == "uploaded" {
+			cloud = "uploaded to cloud"
+		} else if cloud == "failed" {
+			cloud = "cloud upload FAILED"
+		} else if cloud == "skipped" {
+			cloud = "local only"
+		}
+
+		result := fmt.Sprintf("%s — %s (%s, %s)", singleStatus.Status, singleStatus.File, size, cloud)
+		if singleStatus.Timestamp != "" {
+			result += " at " + singleStatus.Timestamp
+		}
+		if singleStatus.Error != "" {
+			result += " [" + singleStatus.Error + "]"
+		}
+		return result
 	}
 
-	info, _ := newest.Info()
-	if info == nil {
-		return newest.Name()
-	}
-
-	return fmt.Sprintf("%s (%s, %s)", newest.Name(), formatSize(info.Size()), info.ModTime().Format("2006-01-02 15:04"))
+	return "no backups found"
 }
 
 func formatSize(bytes int64) string {

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -318,13 +318,13 @@ func getPerDBBackupStatus() map[string]dbBackupInfo {
 
 	var status struct {
 		Timestamp string `json:"timestamp"`
-		Bucket    string `json:"bucket"`
 		Databases []struct {
 			Database    string `json:"database"`
 			Status      string `json:"status"`
 			File        string `json:"file"`
 			SizeBytes   int64  `json:"size_bytes"`
 			CloudUpload string `json:"cloud_upload"`
+			CloudURL    string `json:"cloud_url"`
 			Error       string `json:"error"`
 		} `json:"databases"`
 	}
@@ -337,8 +337,6 @@ func getPerDBBackupStatus() map[string]dbBackupInfo {
 		date = date[:10]
 	}
 
-	hostname, _ := os.Hostname()
-
 	for _, db := range status.Databases {
 		if db.Database == "roles" {
 			continue
@@ -348,7 +346,7 @@ func getPerDBBackupStatus() map[string]dbBackupInfo {
 			cloud := ""
 			if db.CloudUpload == "uploaded" {
 				cloud = ", cloud"
-				info.CloudPath = fmt.Sprintf("%s/%s/%s", status.Bucket, hostname, db.File)
+				info.CloudPath = db.CloudURL
 			} else if db.CloudUpload == "failed" {
 				cloud = ", cloud FAILED"
 			}

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -240,10 +240,15 @@ func (m Model) View() string {
 		b.WriteString(dimStyle.Render("  No databases found"))
 		b.WriteString("\n")
 	} else {
-		b.WriteString(fmt.Sprintf("  %-20s %-16s %s\n", "NAME", "OWNER", "SIZE"))
-		b.WriteString(fmt.Sprintf("  %-20s %-16s %s\n", "----", "-----", "----"))
+		backupMap := getPerDBBackupStatus()
+		b.WriteString(fmt.Sprintf("  %-20s %-16s %-10s %s\n", "NAME", "OWNER", "SIZE", "LAST BACKUP"))
+		b.WriteString(fmt.Sprintf("  %-20s %-16s %-10s %s\n", "----", "-----", "----", "-----------"))
 		for i, d := range m.databases {
-			line := fmt.Sprintf("  %-20s %-16s %s", d.Name, d.Owner, d.Size)
+			backup := ""
+			if bs, ok := backupMap[d.Name]; ok {
+				backup = bs
+			}
+			line := fmt.Sprintf("  %-20s %-16s %-10s %s", d.Name, d.Owner, d.Size, backup)
 			if i == m.selected {
 				b.WriteString(selectedStyle.Render(line))
 			} else {
@@ -283,6 +288,56 @@ func (m Model) View() string {
 	b.WriteString(dimStyle.Render("  [a] Create database  [d] Drop database  [esc] Back"))
 
 	return b.String()
+}
+
+// getPerDBBackupStatus returns a map of database name → short status string.
+func getPerDBBackupStatus() map[string]string {
+	result := make(map[string]string)
+	statusFile := "/var/lib/freedb/backup-status.json"
+	data, err := os.ReadFile(statusFile)
+	if err != nil {
+		return result
+	}
+
+	var status struct {
+		Timestamp string `json:"timestamp"`
+		Databases []struct {
+			Database    string `json:"database"`
+			Status      string `json:"status"`
+			File        string `json:"file"`
+			SizeBytes   int64  `json:"size_bytes"`
+			CloudUpload string `json:"cloud_upload"`
+			Error       string `json:"error"`
+		} `json:"databases"`
+	}
+	if json.Unmarshal(data, &status) != nil || len(status.Databases) == 0 {
+		return result
+	}
+
+	// Extract just the date portion from timestamp (e.g., "2026-04-11")
+	date := status.Timestamp
+	if len(date) >= 10 {
+		date = date[:10]
+	}
+
+	for _, db := range status.Databases {
+		if db.Database == "roles" {
+			continue // don't show roles as a database backup
+		}
+		if db.Status == "success" {
+			cloud := ""
+			if db.CloudUpload == "uploaded" {
+				cloud = ", cloud"
+			} else if db.CloudUpload == "failed" {
+				cloud = ", cloud FAILED"
+			}
+			result[db.Database] = fmt.Sprintf("%s (%s%s)", date, formatSize(db.SizeBytes), cloud)
+		} else {
+			result[db.Database] = "FAILED"
+		}
+	}
+
+	return result
 }
 
 func getLastBackupInfo() string {

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -245,8 +245,8 @@ func (m Model) View() string {
 		b.WriteString(fmt.Sprintf("  %-20s %-16s %-10s %s\n", "----", "-----", "----", "-----------"))
 		for i, d := range m.databases {
 			backup := ""
-			if bs, ok := backupMap[d.Name]; ok {
-				backup = bs
+			if info, ok := backupMap[d.Name]; ok {
+				backup = info.Summary
 			}
 			line := fmt.Sprintf("  %-20s %-16s %-10s %s", d.Name, d.Owner, d.Size, backup)
 			if i == m.selected {
@@ -255,6 +255,17 @@ func (m Model) View() string {
 				b.WriteString(line)
 			}
 			b.WriteString("\n")
+		}
+
+		// Show backup details for selected database
+		if m.selected < len(m.databases) {
+			if info, ok := backupMap[m.databases[m.selected].Name]; ok && info.LocalFile != "" {
+				b.WriteString(dimStyle.Render(fmt.Sprintf("\n  Local:  %s", info.LocalFile)))
+				if info.CloudPath != "" {
+					b.WriteString(dimStyle.Render(fmt.Sprintf("\n  Cloud:  %s", info.CloudPath)))
+				}
+				b.WriteString("\n")
+			}
 		}
 	}
 
@@ -290,9 +301,15 @@ func (m Model) View() string {
 	return b.String()
 }
 
-// getPerDBBackupStatus returns a map of database name → short status string.
-func getPerDBBackupStatus() map[string]string {
-	result := make(map[string]string)
+type dbBackupInfo struct {
+	Summary   string // short string for the table column
+	CloudPath string // cloud bucket path
+	LocalFile string // local file path
+}
+
+// getPerDBBackupStatus returns a map of database name → backup info.
+func getPerDBBackupStatus() map[string]dbBackupInfo {
+	result := make(map[string]dbBackupInfo)
 	statusFile := "/var/lib/freedb/backup-status.json"
 	data, err := os.ReadFile(statusFile)
 	if err != nil {
@@ -301,6 +318,7 @@ func getPerDBBackupStatus() map[string]string {
 
 	var status struct {
 		Timestamp string `json:"timestamp"`
+		Bucket    string `json:"bucket"`
 		Databases []struct {
 			Database    string `json:"database"`
 			Status      string `json:"status"`
@@ -314,27 +332,32 @@ func getPerDBBackupStatus() map[string]string {
 		return result
 	}
 
-	// Extract just the date portion from timestamp (e.g., "2026-04-11")
 	date := status.Timestamp
 	if len(date) >= 10 {
 		date = date[:10]
 	}
 
+	hostname, _ := os.Hostname()
+
 	for _, db := range status.Databases {
 		if db.Database == "roles" {
-			continue // don't show roles as a database backup
+			continue
 		}
+		info := dbBackupInfo{}
 		if db.Status == "success" {
 			cloud := ""
 			if db.CloudUpload == "uploaded" {
 				cloud = ", cloud"
+				info.CloudPath = fmt.Sprintf("%s/%s/%s", status.Bucket, hostname, db.File)
 			} else if db.CloudUpload == "failed" {
 				cloud = ", cloud FAILED"
 			}
-			result[db.Database] = fmt.Sprintf("%s (%s%s)", date, formatSize(db.SizeBytes), cloud)
+			info.Summary = fmt.Sprintf("%s (%s%s)", date, formatSize(db.SizeBytes), cloud)
+			info.LocalFile = fmt.Sprintf("/var/lib/freedb/backups/%s", db.File)
 		} else {
-			result[db.Database] = "FAILED"
+			info.Summary = "FAILED"
 		}
+		result[db.Database] = info
 	}
 
 	return result

--- a/tui/internal/upgrade/files/backup-db.sh
+++ b/tui/internal/upgrade/files/backup-db.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 # FreeDB database backup script
 # Runs on the HOST, not inside the db1 container.
-# Uses incus exec to run pg_dumpall/pg_dump inside db1 and pipes output to the host.
+# Uses incus exec to run pg_dump inside db1 and pipes output to the host.
 # Writes status to /var/lib/freedb/backup-status.json for TUI display.
 #
-# PARAMETERS
-#   $1 - database name (optional — if omitted, runs pg_dumpall for full backup)
+# MODES
+#   No args    — back up all non-system databases + roles
+#   $1 = name  — back up a single database
 #
 # ENVIRONMENT
 #   FREEDB_BACKUP_BUCKET - cloud storage bucket name (default: freedb-backup)
@@ -19,91 +20,132 @@ BACKUP_BUCKET="${FREEDB_BACKUP_BUCKET:-freedb-backup}"
 DB_CONTAINER="${FREEDB_DB_CONTAINER:-db1}"
 CURRENT_DATE=$(date "+%Y%m%d")
 HOSTNAME=$(hostname)
-DB_NAME="${1:-pg_dumpall}"
 START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Ensure backup directory exists
 mkdir -p "$BACKUP_DIRECTORY"
 
+# Upload a file to cloud storage. Sets CLOUD_STATUS and CLOUD_ERROR.
+upload_to_cloud() {
+  local file="$1"
+  local name
+  name=$(basename "$file")
+  CLOUD_STATUS="none"
+  CLOUD_ERROR=""
+
+  if command -v gcloud &>/dev/null; then
+    if gcloud storage cp "$file" "gs://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+      CLOUD_STATUS="uploaded"
+    else
+      CLOUD_STATUS="failed"
+      CLOUD_ERROR="gcloud upload failed"
+    fi
+  elif command -v aws &>/dev/null; then
+    if aws s3 cp "$file" "s3://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+      CLOUD_STATUS="uploaded"
+    else
+      CLOUD_STATUS="failed"
+      CLOUD_ERROR="aws s3 upload failed"
+    fi
+  else
+    CLOUD_STATUS="skipped"
+    CLOUD_ERROR="no cloud CLI found"
+  fi
+}
+
+# Back up a single database (or roles). Appends result to RESULTS array.
+backup_one() {
+  local db_name="$1"
+  local dump_cmd="$2"
+  local fileName="${db_name}_${CURRENT_DATE}.sql.gz"
+  local status="success"
+  local cloud_status="none"
+  local cloud_error=""
+  local file_size=0
+
+  echo -n "Backing up ${db_name}... "
+
+  if ! sudo incus exec "$DB_CONTAINER" -- $dump_cmd | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
+    echo "FAILED"
+    RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"failed\",\"file\":\"${fileName}\",\"size_bytes\":0,\"cloud_upload\":\"none\",\"error\":\"dump failed\"}")
+    return 1
+  fi
+
+  if [ ! -s "$BACKUP_DIRECTORY/$fileName" ]; then
+    echo "FAILED (empty)"
+    RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"failed\",\"file\":\"${fileName}\",\"size_bytes\":0,\"cloud_upload\":\"none\",\"error\":\"backup file empty\"}")
+    return 1
+  fi
+
+  file_size=$(stat -c%s "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || stat -f%z "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || echo "0")
+
+  upload_to_cloud "$BACKUP_DIRECTORY/$fileName"
+  cloud_status="$CLOUD_STATUS"
+  cloud_error="$CLOUD_ERROR"
+
+  local size_human
+  size_human=$(du -h "$BACKUP_DIRECTORY/$fileName" | cut -f1)
+  echo "OK (${size_human}, ${cloud_status})"
+
+  RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"success\",\"file\":\"${fileName}\",\"size_bytes\":${file_size},\"cloud_upload\":\"${cloud_status}\",\"error\":\"${cloud_error}\"}")
+  return 0
+}
+
+# Write status file from RESULTS array
 write_status() {
-  local status="$1"
-  local file="${2:-}"
-  local size="${3:-}"
-  local cloud="${4:-}"
-  local error="${5:-}"
+  local entries=""
+  for i in "${!RESULTS[@]}"; do
+    if [ "$i" -gt 0 ]; then
+      entries="${entries},"
+    fi
+    entries="${entries}
+    ${RESULTS[$i]}"
+  done
 
   cat > "$STATUS_FILE" << STATUSEOF
 {
-  "database": "${DB_NAME}",
-  "status": "${status}",
   "timestamp": "${START_TIME}",
-  "file": "${file}",
-  "size_bytes": ${size:-0},
-  "cloud_upload": "${cloud}",
-  "error": "${error}",
-  "bucket": "${BACKUP_BUCKET}"
+  "bucket": "${BACKUP_BUCKET}",
+  "databases": [${entries}
+  ]
 }
 STATUSEOF
 }
 
-# Run the dump inside db1, pipe to host
-if [ -z "${1:-}" ]; then
-  # Full backup using pg_dumpall (includes users/roles)
-  fileName="pg_dumpall_${CURRENT_DATE}.sql.gz"
-  if ! sudo incus exec "$DB_CONTAINER" -- sudo -u postgres pg_dumpall | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
-    write_status "failed" "$fileName" "0" "none" "pg_dumpall failed"
-    echo "Backup failed: pg_dumpall error"
-    exit 1
-  fi
+# Collect results
+RESULTS=()
+FAILURES=0
+
+if [ -n "${1:-}" ]; then
+  # Single database mode
+  backup_one "$1" "sudo -u postgres pg_dump $1" || FAILURES=$((FAILURES + 1))
 else
-  # Single database backup
-  fileName="${1}_${CURRENT_DATE}.sql.gz"
-  if ! sudo incus exec "$DB_CONTAINER" -- sudo -u postgres pg_dump "$1" | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
-    write_status "failed" "$fileName" "0" "none" "pg_dump failed for $1"
-    echo "Backup failed: pg_dump error for $1"
-    exit 1
-  fi
-fi
+  # Full backup mode: roles + all user databases
 
-# Verify the backup was created
-if [ ! -f "$BACKUP_DIRECTORY/$fileName" ] || [ ! -s "$BACKUP_DIRECTORY/$fileName" ]; then
-  write_status "failed" "$fileName" "0" "none" "backup file missing or empty"
-  echo "Backup failed: $fileName is missing or empty"
-  exit 1
-fi
+  # 1. Dump roles (users/passwords)
+  backup_one "roles" "sudo -u postgres pg_dumpall --roles-only" || FAILURES=$((FAILURES + 1))
 
-FILE_SIZE=$(stat -c%s "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || stat -f%z "$BACKUP_DIRECTORY/$fileName" 2>/dev/null || echo "0")
-echo "Backup created: $BACKUP_DIRECTORY/$fileName ($(du -h "$BACKUP_DIRECTORY/$fileName" | cut -f1))"
+  # 2. List non-system databases and back up each
+  DB_LIST=$(sudo incus exec "$DB_CONTAINER" -- sudo -u postgres psql -At -c \
+    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres')" 2>/dev/null || echo "")
 
-# Upload to cloud storage using the host's cloud CLI
-CLOUD_STATUS="none"
-CLOUD_ERROR=""
-if command -v gcloud &>/dev/null; then
-  if gcloud storage cp "$BACKUP_DIRECTORY/$fileName" "gs://${BACKUP_BUCKET}/${HOSTNAME}/$fileName" 2>/dev/null; then
-    CLOUD_STATUS="uploaded"
-    echo "Uploaded to gs://${BACKUP_BUCKET}/${HOSTNAME}/$fileName"
+  if [ -z "$DB_LIST" ]; then
+    echo "Warning: No user databases found"
   else
-    CLOUD_STATUS="failed"
-    CLOUD_ERROR="gcloud upload failed"
-    echo "Warning: Cloud upload failed"
+    while IFS= read -r db; do
+      [ -z "$db" ] && continue
+      backup_one "$db" "sudo -u postgres pg_dump $db" || FAILURES=$((FAILURES + 1))
+    done <<< "$DB_LIST"
   fi
-elif command -v aws &>/dev/null; then
-  if aws s3 cp "$BACKUP_DIRECTORY/$fileName" "s3://${BACKUP_BUCKET}/${HOSTNAME}/$fileName" 2>/dev/null; then
-    CLOUD_STATUS="uploaded"
-    echo "Uploaded to s3://${BACKUP_BUCKET}/${HOSTNAME}/$fileName"
-  else
-    CLOUD_STATUS="failed"
-    CLOUD_ERROR="aws s3 upload failed"
-    echo "Warning: Cloud upload failed"
-  fi
-else
-  CLOUD_STATUS="skipped"
-  CLOUD_ERROR="no cloud CLI found"
-  echo "Warning: No cloud CLI found — backup saved locally only"
 fi
 
-# Write final status
-write_status "success" "$fileName" "$FILE_SIZE" "$CLOUD_STATUS" "$CLOUD_ERROR"
+write_status
 
 # Delete local backups older than 30 days
 find "$BACKUP_DIRECTORY" -type f -name "*.sql.gz" -mtime +30 -delete
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "Backup completed with $FAILURES failure(s)"
+  exit 1
+fi
+
+echo "All backups completed successfully"

--- a/tui/internal/upgrade/files/backup-db.sh
+++ b/tui/internal/upgrade/files/backup-db.sh
@@ -31,20 +31,25 @@ upload_to_cloud() {
   name=$(basename "$file")
   CLOUD_STATUS="none"
   CLOUD_ERROR=""
+  CLOUD_URL=""
 
   if command -v gcloud &>/dev/null; then
-    if gcloud storage cp "$file" "gs://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+    CLOUD_URL="gs://${BACKUP_BUCKET}/${HOSTNAME}/$name"
+    if gcloud storage cp "$file" "$CLOUD_URL" 2>/dev/null; then
       CLOUD_STATUS="uploaded"
     else
       CLOUD_STATUS="failed"
       CLOUD_ERROR="gcloud upload failed"
+      CLOUD_URL=""
     fi
   elif command -v aws &>/dev/null; then
-    if aws s3 cp "$file" "s3://${BACKUP_BUCKET}/${HOSTNAME}/$name" 2>/dev/null; then
+    CLOUD_URL="s3://${BACKUP_BUCKET}/${HOSTNAME}/$name"
+    if aws s3 cp "$file" "$CLOUD_URL" 2>/dev/null; then
       CLOUD_STATUS="uploaded"
     else
       CLOUD_STATUS="failed"
       CLOUD_ERROR="aws s3 upload failed"
+      CLOUD_URL=""
     fi
   else
     CLOUD_STATUS="skipped"
@@ -81,12 +86,13 @@ backup_one() {
   upload_to_cloud "$BACKUP_DIRECTORY/$fileName"
   cloud_status="$CLOUD_STATUS"
   cloud_error="$CLOUD_ERROR"
+  local cloud_url="$CLOUD_URL"
 
   local size_human
   size_human=$(du -h "$BACKUP_DIRECTORY/$fileName" | cut -f1)
   echo "OK (${size_human}, ${cloud_status})"
 
-  RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"success\",\"file\":\"${fileName}\",\"size_bytes\":${file_size},\"cloud_upload\":\"${cloud_status}\",\"error\":\"${cloud_error}\"}")
+  RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"success\",\"file\":\"${fileName}\",\"size_bytes\":${file_size},\"cloud_upload\":\"${cloud_status}\",\"cloud_url\":\"${cloud_url}\",\"error\":\"${cloud_error}\"}")
   return 0
 }
 

--- a/tui/internal/upgrade/files/backup-db.sh
+++ b/tui/internal/upgrade/files/backup-db.sh
@@ -64,7 +64,7 @@ backup_one() {
 
   echo -n "Backing up ${db_name}... "
 
-  if ! sudo incus exec "$DB_CONTAINER" -- $dump_cmd | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
+  if ! sudo incus exec "$DB_CONTAINER" -- $dump_cmd < /dev/null | gzip > "$BACKUP_DIRECTORY/$fileName" 2>/dev/null; then
     echo "FAILED"
     RESULTS+=("{\"database\":\"${db_name}\",\"status\":\"failed\",\"file\":\"${fileName}\",\"size_bytes\":0,\"cloud_upload\":\"none\",\"error\":\"dump failed\"}")
     return 1

--- a/tui/internal/upgrade/migrations/v0.5.sh
+++ b/tui/internal/upgrade/migrations/v0.5.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Migration: v0.4 → v0.5
+# - Update backup script to per-database backups
+
+echo "=== Migration v0.5: Per-database backups ==="
+
+echo "1. Updating backup script..."
+freedb install-backup-script 2>/dev/null || {
+  echo "   Warning: Could not install backup script via freedb."
+  echo "   Manually copy ops/backup-db.sh to /opt/freedb/backup-db.sh"
+}
+
+echo ""
+echo "=== Migration v0.5 complete ==="
+echo ""
+echo "Backups now create individual files per database instead of a single pg_dumpall."
+echo "Old backups will be cleaned up automatically after 30 days."
+echo ""
+echo "To test: sudo bash -c '. /opt/freedb/backup.env && /opt/freedb/backup-db.sh'"

--- a/tui/internal/upgrade/upgrade.go
+++ b/tui/internal/upgrade/upgrade.go
@@ -26,6 +26,7 @@ type Migration struct {
 var migrations = []Migration{
 	{Version: "v0.3", Script: "v0.3.sh"},
 	{Version: "v0.4", Script: "v0.4.sh"},
+	{Version: "v0.5", Script: "v0.5.sh"},
 }
 
 // InstallBackupScript writes the embedded backup script to /opt/freedb/


### PR DESCRIPTION
## Summary

Replaces the monolithic `pg_dumpall` backup with per-database dumps:

```
/var/lib/freedb/backups/
  roles_20260410.sql.gz      # pg_dumpall --roles-only
  mydb1_20260410.sql.gz      # pg_dump mydb1
  mydb2_20260410.sql.gz      # pg_dump mydb2
```

- Each database backed up and uploaded individually
- Roles dump preserves users/passwords separately
- Status JSON now tracks per-database success/failure
- TUI shows summary: "3 databases (450 KB, uploaded to cloud)"
- Backward-compatible: TUI reads both old and new status formats
- Single-database mode still works: `backup-db.sh mydb`
- v0.5 migration installs the updated script

Closes #38

## Test plan

- [x] Run `sudo bash -c '. /opt/freedb/backup.env && /opt/freedb/backup-db.sh'` — verify per-db files created
- [x] Check `/var/lib/freedb/backup-status.json` has `databases` array
- [x] Run single-db mode: `backup-db.sh mydb` — verify only that DB backed up
- [x] Verify TUI databases view shows new backup summary
- [x] Verify TUI still reads old-format status files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)