### PR TITLE
Add database restore via TUI and CLI

### DIFF
--- a/ops/backup-db.sh
+++ b/ops/backup-db.sh
@@ -18,7 +18,7 @@ BACKUP_DIRECTORY="/var/lib/freedb/backups"
 STATUS_FILE="/var/lib/freedb/backup-status.json"
 BACKUP_BUCKET="${FREEDB_BACKUP_BUCKET:-freedb-backup}"
 DB_CONTAINER="${FREEDB_DB_CONTAINER:-db1}"
-CURRENT_DATE=$(date "+%Y%m%d")
+CURRENT_DATE=$(date -u "+%Y%m%d_%H%M%SZ")
 HOSTNAME=$(hostname)
 START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 

--- a/tui/internal/db/postgres.go
+++ b/tui/internal/db/postgres.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/danbiagini/FreeDB/tui/internal/incus"
@@ -107,6 +109,87 @@ func ListDatabases(ctx context.Context, ic *incus.Client) ([]DatabaseInfo, error
 	}
 
 	return dbs, nil
+}
+
+// BackupFile represents a local backup file for a database.
+type BackupFile struct {
+	Name string // filename
+	Date string // extracted date (YYYYMMDD)
+	Path string // full path
+	Size int64
+}
+
+// ListBackupFiles returns available backup files for a given database name,
+// sorted newest first.
+func ListBackupFiles(dbName string) ([]BackupFile, error) {
+	backupDir := "/var/lib/freedb/backups"
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading backup directory: %w", err)
+	}
+
+	prefix := dbName + "_"
+	var files []BackupFile
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), prefix) || !strings.HasSuffix(e.Name(), ".sql.gz") {
+			continue
+		}
+		// Extract date from filename: dbname_YYYYMMDD.sql.gz
+		datePart := strings.TrimPrefix(e.Name(), prefix)
+		datePart = strings.TrimSuffix(datePart, ".sql.gz")
+
+		info, _ := e.Info()
+		size := int64(0)
+		if info != nil {
+			size = info.Size()
+		}
+
+		files = append(files, BackupFile{
+			Name: e.Name(),
+			Date: datePart,
+			Path: backupDir + "/" + e.Name(),
+			Size: size,
+		})
+	}
+
+	// Sort newest first (dates are YYYYMMDD so reverse string sort works)
+	for i := 0; i < len(files); i++ {
+		for j := i + 1; j < len(files); j++ {
+			if files[j].Date > files[i].Date {
+				files[i], files[j] = files[j], files[i]
+			}
+		}
+	}
+
+	return files, nil
+}
+
+// RestoreDatabase restores a database from a gzipped SQL dump file.
+// It drops and recreates the database before restoring.
+func RestoreDatabase(ctx context.Context, ic *incus.Client, dbName, backupPath string) error {
+	// Drop existing database (ignore error if it doesn't exist)
+	_, _ = ic.Exec(ctx, dbContainer, []string{
+		"sudo", "-u", "postgres", "dropdb", "--if-exists", dbName,
+	})
+
+	// Recreate the database owned by the same user
+	_, err := ic.Exec(ctx, dbContainer, []string{
+		"sudo", "-u", "postgres", "createdb", "-O", dbName, dbName,
+	})
+	if err != nil {
+		return fmt.Errorf("recreating database %s: %w", dbName, err)
+	}
+
+	// Restore: gunzip the backup and pipe into psql via incus exec
+	// We run this on the host since the backup file is on the host filesystem
+	cmd := fmt.Sprintf("gunzip -c %s | sudo incus exec %s -- sudo -u postgres psql -d %s", backupPath, dbContainer, dbName)
+	execCmd := exec.CommandContext(ctx, "bash", "-c", cmd)
+	output, err := execCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("restoring %s: %s", dbName, strings.TrimSpace(string(output)))
+	}
+
+	return nil
 }
 
 func GetDBConnectionString(dbIP, name, password string) string {

--- a/tui/internal/db/postgres.go
+++ b/tui/internal/db/postgres.go
@@ -134,7 +134,7 @@ func ListBackupFiles(dbName string) ([]BackupFile, error) {
 		if e.IsDir() || !strings.HasPrefix(e.Name(), prefix) || !strings.HasSuffix(e.Name(), ".sql.gz") {
 			continue
 		}
-		// Extract date from filename: dbname_YYYYMMDD.sql.gz
+		// Extract timestamp from filename: dbname_YYYYMMDD_HHMMSSZ.sql.gz
 		datePart := strings.TrimPrefix(e.Name(), prefix)
 		datePart = strings.TrimSuffix(datePart, ".sql.gz")
 

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -22,6 +22,8 @@ const (
 	subviewCreateName
 	subviewCreateDone
 	subviewConfirmDrop
+	subviewRestoreSelect
+	subviewConfirmRestore
 )
 
 type listResult struct {
@@ -41,17 +43,19 @@ type actionResult struct {
 }
 
 type Model struct {
-	incusClient *incus.Client
-	subview     subview
-	databases   []db.DatabaseInfo
-	selected    int
-	nameInput   textinput.Model
-	lastCreated string
+	incusClient  *incus.Client
+	subview      subview
+	databases    []db.DatabaseInfo
+	selected     int
+	nameInput    textinput.Model
+	lastCreated  string
 	lastPassword string
-	message     string
-	err         error
-	done        bool
-	busy        bool
+	message      string
+	err          error
+	done         bool
+	busy         bool
+	backupFiles  []db.BackupFile
+	backupSel    int
 }
 
 func NewModel(ic *incus.Client) Model {
@@ -145,6 +149,19 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.subview = subviewConfirmDrop
 			}
 			return m, nil
+		case "r":
+			if len(m.databases) > 0 && m.selected < len(m.databases) {
+				files, err := db.ListBackupFiles(m.databases[m.selected].Name)
+				if err != nil || len(files) == 0 {
+					m.err = fmt.Errorf("no backups found for %s", m.databases[m.selected].Name)
+					return m, nil
+				}
+				m.backupFiles = files
+				m.backupSel = 0
+				m.err = nil
+				m.subview = subviewRestoreSelect
+			}
+			return m, nil
 		case "up", "k":
 			if m.selected > 0 {
 				m.selected--
@@ -192,6 +209,44 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.subview = subviewList
 			return m, nil
 		}
+
+	case subviewRestoreSelect:
+		switch key {
+		case "esc":
+			m.subview = subviewList
+			return m, nil
+		case "up", "k":
+			if m.backupSel > 0 {
+				m.backupSel--
+			}
+			return m, nil
+		case "down", "j":
+			if m.backupSel < len(m.backupFiles)-1 {
+				m.backupSel++
+			}
+			return m, nil
+		case "enter":
+			m.subview = subviewConfirmRestore
+			return m, nil
+		}
+
+	case subviewConfirmRestore:
+		switch key {
+		case "y":
+			if m.selected < len(m.databases) && m.backupSel < len(m.backupFiles) {
+				m.busy = true
+				m.subview = subviewList
+				return m, m.restoreDatabase(
+					m.databases[m.selected].Name,
+					m.backupFiles[m.backupSel].Path,
+				)
+			}
+			m.subview = subviewList
+			return m, nil
+		case "n", "esc":
+			m.subview = subviewRestoreSelect
+			return m, nil
+		}
 	}
 
 	return m, nil
@@ -233,6 +288,32 @@ func (m Model) View() string {
 			b.WriteString(errStyle.Render(fmt.Sprintf("  %v", m.err)) + "\n")
 		}
 		b.WriteString(dimStyle.Render("  [enter] Create  [esc] Cancel"))
+		return b.String()
+	}
+
+	if m.subview == subviewRestoreSelect || m.subview == subviewConfirmRestore {
+		dbName := ""
+		if m.selected < len(m.databases) {
+			dbName = m.databases[m.selected].Name
+		}
+		b.WriteString(fmt.Sprintf("  Restore %s from backup:\n\n", dbName))
+		for i, f := range m.backupFiles {
+			size := formatSize(f.Size)
+			line := fmt.Sprintf("  %s  (%s)", f.Date, size)
+			if i == m.backupSel {
+				b.WriteString(selectedStyle.Render(line))
+			} else {
+				b.WriteString(line)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		if m.subview == subviewConfirmRestore {
+			b.WriteString(warnStyle.Render(fmt.Sprintf("  Restore %s from %s? This will DROP and recreate the database. [y/n]",
+				dbName, m.backupFiles[m.backupSel].Date)))
+		} else {
+			b.WriteString(dimStyle.Render("  [enter] Select  [esc] Cancel"))
+		}
 		return b.String()
 	}
 
@@ -296,7 +377,7 @@ func (m Model) View() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  [a] Create database  [d] Drop database  [esc] Back"))
+	b.WriteString(dimStyle.Render("  [a] Create  [d] Drop  [r] Restore  [esc] Back"))
 
 	return b.String()
 }
@@ -486,5 +567,15 @@ func (m Model) dropDatabase(name string) tea.Cmd {
 			return actionResult{err: err}
 		}
 		return actionResult{msg: fmt.Sprintf("Database %q dropped", name)}
+	}
+}
+
+func (m Model) restoreDatabase(name, backupPath string) tea.Cmd {
+	ic := m.incusClient
+	return func() tea.Msg {
+		if err := db.RestoreDatabase(context.Background(), ic, name, backupPath); err != nil {
+			return actionResult{err: err}
+		}
+		return actionResult{msg: fmt.Sprintf("Database %q restored from %s", name, backupPath)}
 	}
 }

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/danbiagini/FreeDB/tui/internal/db"
 	"github.com/danbiagini/FreeDB/tui/internal/incus"
+	"github.com/danbiagini/FreeDB/tui/internal/registry"
 )
 
 type subview int
@@ -44,6 +45,7 @@ type actionResult struct {
 
 type Model struct {
 	incusClient  *incus.Client
+	registry     *registry.AppRegistry
 	subview      subview
 	databases    []db.DatabaseInfo
 	selected     int
@@ -58,13 +60,14 @@ type Model struct {
 	backupSel    int
 }
 
-func NewModel(ic *incus.Client) Model {
+func NewModel(ic *incus.Client, reg *registry.AppRegistry) Model {
 	input := textinput.New()
 	input.Placeholder = "mydb"
 	input.CharLimit = 30
 
 	return Model{
 		incusClient: ic,
+		registry:    reg,
 		subview:     subviewList,
 		nameInput:   input,
 	}
@@ -572,10 +575,30 @@ func (m Model) dropDatabase(name string) tea.Cmd {
 
 func (m Model) restoreDatabase(name, backupPath string) tea.Cmd {
 	ic := m.incusClient
+	reg := m.registry
 	return func() tea.Msg {
-		if err := db.RestoreDatabase(context.Background(), ic, name, backupPath); err != nil {
+		ctx := context.Background()
+		if err := db.RestoreDatabase(ctx, ic, name, backupPath); err != nil {
 			return actionResult{err: err}
 		}
-		return actionResult{msg: fmt.Sprintf("Database %q restored from %s", name, backupPath)}
+
+		// Restart the app container that uses this database
+		msg := fmt.Sprintf("Database %q restored", name)
+		if reg != nil {
+			for _, app := range reg.List() {
+				if app.HasDB && app.DBName == name {
+					cName := app.Name
+					if app.ContainerName != "" {
+						cName = app.ContainerName
+					}
+					_ = ic.StopContainer(ctx, cName)
+					_ = ic.StartContainer(ctx, cName)
+					msg += fmt.Sprintf(", restarted %s", cName)
+					break
+				}
+			}
+		}
+
+		return actionResult{msg: msg}
 	}
 }

--- a/tui/internal/tui/model.go
+++ b/tui/internal/tui/model.go
@@ -90,7 +90,7 @@ func (m Model) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.current = viewRemotes
 			return m, rm.Init()
 		case "D":
-			dbm := databases.NewModel(m.incus)
+			dbm := databases.NewModel(m.incus, m.registry)
 			m.dbs = &dbm
 			m.current = viewDatabases
 			return m, dbm.Init()

--- a/tui/internal/upgrade/files/backup-db.sh
+++ b/tui/internal/upgrade/files/backup-db.sh
@@ -18,7 +18,7 @@ BACKUP_DIRECTORY="/var/lib/freedb/backups"
 STATUS_FILE="/var/lib/freedb/backup-status.json"
 BACKUP_BUCKET="${FREEDB_BACKUP_BUCKET:-freedb-backup}"
 DB_CONTAINER="${FREEDB_DB_CONTAINER:-db1}"
-CURRENT_DATE=$(date "+%Y%m%d")
+CURRENT_DATE=$(date -u "+%Y%m%d_%H%M%SZ")
 HOSTNAME=$(hostname)
 START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 

--- a/tui/main.go
+++ b/tui/main.go
@@ -590,6 +590,24 @@ func runRestore(args []string) int {
 	}
 
 	fmt.Printf("Database %s restored successfully.\n", dbName)
+
+	// Restart the app container that uses this database
+	reg, err := registry.Load("/etc/freedb/registry.json")
+	if err == nil {
+		for _, app := range reg.List() {
+			if app.HasDB && app.DBName == dbName {
+				cName := app.Name
+				if app.ContainerName != "" {
+					cName = app.ContainerName
+				}
+				fmt.Printf("Restarting %s...\n", cName)
+				ctx := context.Background()
+				_ = ic.StopContainer(ctx, cName)
+				_ = ic.StartContainer(ctx, cName)
+				break
+			}
+		}
+	}
 	return 0
 }
 

--- a/tui/main.go
+++ b/tui/main.go
@@ -62,6 +62,8 @@ func main() {
 			os.Exit(0)
 		case "acme-email":
 			os.Exit(runAcmeEmail(os.Args[2:]))
+		case "restore":
+			os.Exit(runRestore(os.Args[2:]))
 		case "--help", "-h", "help":
 			printHelp()
 			os.Exit(0)
@@ -514,6 +516,83 @@ func runAcmeEmail(args []string) int {
 	return 0
 }
 
+func runRestore(args []string) int {
+	if len(args) < 1 || args[0] == "--help" || args[0] == "-h" {
+		fmt.Println("Usage: sudo freedb restore <database> [date]")
+		fmt.Println()
+		fmt.Println("Restore a database from a backup file.")
+		fmt.Println("If date is omitted, lists available backups.")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  sudo freedb restore mydb              List available backups")
+		fmt.Println("  sudo freedb restore mydb 20260411     Restore from specific date")
+		return 0
+	}
+
+	dbName := args[0]
+
+	files, err := db.ListBackupFiles(dbName)
+	if err != nil || len(files) == 0 {
+		fmt.Fprintf(os.Stderr, "No backups found for %s\n", dbName)
+		return 1
+	}
+
+	// No date: list available backups
+	if len(args) < 2 {
+		fmt.Printf("Available backups for %s:\n", dbName)
+		for _, f := range files {
+			size := ""
+			if f.Size > 1024*1024 {
+				size = fmt.Sprintf("%.1f MB", float64(f.Size)/(1024*1024))
+			} else if f.Size > 1024 {
+				size = fmt.Sprintf("%.1f KB", float64(f.Size)/1024)
+			} else {
+				size = fmt.Sprintf("%d B", f.Size)
+			}
+			fmt.Printf("  %s  (%s)  %s\n", f.Date, size, f.Path)
+		}
+		return 0
+	}
+
+	// Find matching backup
+	date := args[1]
+	var match *db.BackupFile
+	for i := range files {
+		if files[i].Date == date {
+			match = &files[i]
+			break
+		}
+	}
+	if match == nil {
+		fmt.Fprintf(os.Stderr, "No backup found for %s on %s\n", dbName, date)
+		return 1
+	}
+
+	fmt.Printf("Restoring %s from %s (%s)...\n", dbName, match.Date, match.Path)
+	fmt.Printf("WARNING: This will DROP and recreate the database.\n")
+	fmt.Print("Type 'yes' to confirm: ")
+	var confirm string
+	fmt.Scanln(&confirm)
+	if confirm != "yes" {
+		fmt.Println("Aborted.")
+		return 0
+	}
+
+	ic, err := incus.Connect("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error connecting to incus: %v\n", err)
+		return 1
+	}
+
+	if err := db.RestoreDatabase(context.Background(), ic, dbName, match.Path); err != nil {
+		fmt.Fprintf(os.Stderr, "Restore failed: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("Database %s restored successfully.\n", dbName)
+	return 0
+}
+
 func printHelp() {
 	fmt.Println("freedb — FreeDB app manager")
 	fmt.Println()
@@ -523,6 +602,7 @@ func printHelp() {
 	fmt.Println("  sudo freedb status APP   Show detailed app status")
 	fmt.Println("  sudo freedb deploy       Deploy/update an app (for CI/CD)")
 	fmt.Println("  sudo freedb destroy APP  Delete an app and all its resources")
+	fmt.Println("  sudo freedb restore DB [DATE]  Restore a database from backup")
 	fmt.Println("  sudo freedb upgrade      Run pending platform migrations")
 	fmt.Println("  sudo freedb acme-email [EMAIL]  Get or set Let's Encrypt notification email")
 	fmt.Println("  sudo freedb check        Run health checks")


### PR DESCRIPTION
## Summary

Two restore paths:

**TUI** (Databases view):
- Press `[r]` on a selected database to see available backup files
- Navigate with arrow keys, `[enter]` to select
- Confirmation prompt warns about DROP + recreate

**CLI**:
- `sudo freedb restore mydb` — lists available backups with dates and sizes
- `sudo freedb restore mydb 20260411` — restores from a specific date with confirmation

**How restore works**:
1. Drops the existing database (`dropdb --if-exists`)
2. Recreates it with the same owner (`createdb -O`)
3. Pipes the gzipped backup through `psql` via `incus exec`

Closes #43

## Test plan

- [x] Create a test database, add data, run backup
- [x] Restore from TUI — verify data is restored
- [ ] Restore from CLI — `sudo freedb restore <db> <date>`
- [x] Verify `sudo freedb restore <db>` lists available backups
- [x] Verify restore of non-existent database name fails gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)