### PR TITLE
Harden upgrade path with --from flag and retry guidance

### DIFF
--- a/tui/internal/upgrade/upgrade.go
+++ b/tui/internal/upgrade/upgrade.go
@@ -58,26 +58,33 @@ func LatestVersion() string {
 	return migrations[len(migrations)-1].Version
 }
 
-func PendingMigrations() []Migration {
-	current := CurrentVersion()
+func PendingFrom(from string) []Migration {
 	var pending []Migration
 	for _, m := range migrations {
-		if m.Version > current {
+		if m.Version > from {
 			pending = append(pending, m)
 		}
 	}
 	return pending
 }
 
-func Run(dryRun bool) int {
+func PendingMigrations() []Migration {
+	return PendingFrom(CurrentVersion())
+}
+
+func Run(dryRun bool, fromVersion string) int {
 	current := CurrentVersion()
+	if fromVersion != "" {
+		current = fromVersion
+		fmt.Printf("Overriding detected version with: %s\n", current)
+	}
 	latest := LatestVersion()
 
 	fmt.Printf("Current version: %s\n", current)
 	fmt.Printf("Target version:  %s\n", latest)
 	fmt.Println()
 
-	pending := PendingMigrations()
+	pending := PendingFrom(current)
 	if len(pending) == 0 {
 		fmt.Println("Already up to date.")
 		return 0
@@ -116,14 +123,22 @@ func Run(dryRun bool) int {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: migration %s failed: %v\n", m.Version, err)
+			fmt.Fprintf(os.Stderr, "\nError: migration %s failed: %v\n", m.Version, err)
+			fmt.Fprintf(os.Stderr, "\nThe migration scripts are idempotent and safe to re-run.\n")
+			fmt.Fprintf(os.Stderr, "To retry this migration:\n")
+			fmt.Fprintf(os.Stderr, "  sudo freedb upgrade --from %s\n", current)
+			fmt.Fprintf(os.Stderr, "\nTo skip it and continue from the next version:\n")
+			fmt.Fprintf(os.Stderr, "  sudo freedb upgrade --from %s\n", m.Version)
 			return 1
 		}
 
-		// Update version file
+		// Update version file after each successful migration
 		os.MkdirAll(filepath.Dir(versionFile), 0755)
 		os.WriteFile(versionFile, []byte(m.Version+"\n"), 0644)
 		fmt.Printf("Updated version to %s\n\n", m.Version)
+
+		// Update current for error messages in subsequent iterations
+		current = m.Version
 	}
 
 	fmt.Println("Upgrade complete.")

--- a/tui/main.go
+++ b/tui/main.go
@@ -450,20 +450,28 @@ func runDestroy(args []string) int {
 
 func runUpgrade(args []string) int {
 	dryRun := false
-	for _, a := range args {
+	fromVersion := ""
+	for i, a := range args {
 		if a == "--dry-run" {
 			dryRun = true
 		}
+		if a == "--from" && i+1 < len(args) {
+			fromVersion = args[i+1]
+		}
 		if a == "--help" || a == "-h" {
-			fmt.Println("Usage: sudo freedb upgrade [--dry-run]")
+			fmt.Println("Usage: sudo freedb upgrade [--dry-run] [--from VERSION]")
 			fmt.Println()
 			fmt.Println("Run pending platform migrations to upgrade FreeDB.")
 			fmt.Println("Migration scripts are embedded in the binary — no repo clone needed.")
+			fmt.Println()
+			fmt.Println("Options:")
+			fmt.Println("  --dry-run       Show pending migrations without running them")
+			fmt.Println("  --from VERSION  Override detected version (e.g., --from v0.3)")
 			return 0
 		}
 	}
 
-	return upgrade.Run(dryRun)
+	return upgrade.Run(dryRun, fromVersion)
 }
 
 func runAcmeEmail(args []string) int {


### PR DESCRIPTION
## Summary

- `--from VERSION` flag overrides detected version, useful for retrying or skipping migrations
- On failure, prints clear instructions:
  ```
  Error: migration v0.4 failed: exit status 1

  The migration scripts are idempotent and safe to re-run.
  To retry this migration:
    sudo freedb upgrade --from v0.3
  
  To skip it and continue from the next version:
    sudo freedb upgrade --from v0.4
  ```
- `--dry-run` still works to preview pending migrations

Closes #44

## Test plan

- [x] `sudo freedb upgrade --dry-run` shows pending migrations
- [x] `sudo freedb upgrade --from v0.3` runs migrations from v0.4 onward
- [x] Verify failure message includes correct retry commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)