### PR TITLE
Add resource summary totals to TUI dashboard

### DIFF
--- a/tui/internal/config/config.go
+++ b/tui/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	RegistryPath   string `json:"registry_path"`
 	ProxyContainer string `json:"proxy_container"`
 	DBContainer    string `json:"db_container"`
+	StoragePool    string `json:"storage_pool"`
 	IncusSocket    string `json:"incus_socket"`
 	Version        string `json:"-"`
 }
@@ -19,6 +20,7 @@ func DefaultConfig() *Config {
 		RegistryPath:   "/etc/freedb/registry.json",
 		ProxyContainer: "proxy1",
 		DBContainer:    "db1",
+		StoragePool:    "pd-standard",
 		IncusSocket:    "",
 	}
 }

--- a/tui/internal/incus/client.go
+++ b/tui/internal/incus/client.go
@@ -560,3 +560,21 @@ func (c *Client) WaitForIP(ctx context.Context, name string, timeout time.Durati
 	}
 	return "", fmt.Errorf("timeout waiting for IP on %s", name)
 }
+
+// StoragePoolUsage holds disk usage for a storage pool.
+type StoragePoolUsage struct {
+	UsedBytes  uint64
+	TotalBytes uint64
+}
+
+// GetStoragePoolUsage returns disk usage for the named storage pool.
+func (c *Client) GetStoragePoolUsage(poolName string) (*StoragePoolUsage, error) {
+	resources, err := c.conn.GetStoragePoolResources(poolName)
+	if err != nil {
+		return nil, fmt.Errorf("getting storage pool resources: %w", err)
+	}
+	return &StoragePoolUsage{
+		UsedBytes:  resources.Space.Used,
+		TotalBytes: resources.Space.Total,
+	}, nil
+}

--- a/tui/internal/tui/dashboard/model.go
+++ b/tui/internal/tui/dashboard/model.go
@@ -43,6 +43,8 @@ type refreshMsg struct {
 	containers  []containerData
 	cpuReadings map[string]float64
 	metrics     map[string]*traefik.ServiceMetrics
+	diskUsed    uint64
+	diskTotal   uint64
 	err         error
 }
 
@@ -59,6 +61,10 @@ type Model struct {
 	curMetrics  map[string]*traefik.ServiceMetrics
 	hostInfo    *config.HostInfo
 	showVersion bool
+	totalMemMB  int64
+	totalCPU    float64
+	diskUsed    uint64
+	diskTotal   uint64
 	err         error
 }
 
@@ -148,16 +154,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			// Update disk usage
+			m.diskUsed = msg.diskUsed
+			m.diskTotal = msg.diskTotal
+
 			// Build rows with latest cpuPercent
+			m.totalMemMB = 0
+			m.totalCPU = 0
 			var rows []table.Row
 			for _, cd := range msg.containers {
 				mem := "—"
 				if cd.info.MemUsageMB > 0 {
 					mem = fmt.Sprintf("%dMB", cd.info.MemUsageMB)
+					m.totalMemMB += cd.info.MemUsageMB
 				}
 
 				cpu := "—"
 				if pct, ok := m.cpuPercent[cd.info.Name]; ok && strings.EqualFold(cd.info.Status, "running") {
+					m.totalCPU += pct
 					if pct < 0.1 {
 						cpu = "<0.1%"
 					} else {
@@ -225,6 +239,29 @@ func (m Model) View() string {
 
 	b.WriteString(m.table.View())
 	b.WriteString("\n")
+
+	// Resource summary
+	var parts []string
+	if m.totalMemMB > 0 {
+		if m.totalMemMB >= 1024 {
+			parts = append(parts, fmt.Sprintf("Mem: %.1f GB", float64(m.totalMemMB)/1024))
+		} else {
+			parts = append(parts, fmt.Sprintf("Mem: %d MB", m.totalMemMB))
+		}
+	}
+	if m.totalCPU > 0 {
+		parts = append(parts, fmt.Sprintf("CPU: %.1f%%", m.totalCPU))
+	}
+	if m.diskTotal > 0 {
+		usedGB := float64(m.diskUsed) / (1024 * 1024 * 1024)
+		totalGB := float64(m.diskTotal) / (1024 * 1024 * 1024)
+		pct := float64(m.diskUsed) / float64(m.diskTotal) * 100
+		parts = append(parts, fmt.Sprintf("Disk: %.1f/%.0f GB (%.0f%%)", usedGB, totalGB, pct))
+	}
+	if len(parts) > 0 {
+		b.WriteString(helpStyle.Render("  " + strings.Join(parts, "  |  ")))
+		b.WriteString("\n")
+	}
 
 	if m.err != nil {
 		b.WriteString(errorStyle.Render(fmt.Sprintf("Error: %v", m.err)))
@@ -342,6 +379,15 @@ func (m Model) refresh() tea.Cmd {
 			})
 		}
 
-		return refreshMsg{containers: data, cpuReadings: cpuReadings, metrics: metrics}
+		// Fetch storage pool usage (best effort)
+		var diskUsed, diskTotal uint64
+		if m.cfg.StoragePool != "" {
+			if usage, err := m.incusClient.GetStoragePoolUsage(m.cfg.StoragePool); err == nil {
+				diskUsed = usage.UsedBytes
+				diskTotal = usage.TotalBytes
+			}
+		}
+
+		return refreshMsg{containers: data, cpuReadings: cpuReadings, metrics: metrics, diskUsed: diskUsed, diskTotal: diskTotal}
 	}
 }


### PR DESCRIPTION
## Summary

Adds a summary line below the container table on the dashboard:

```
  Mem: 1.2 GB  |  CPU: 3.4%  |  Disk: 12.3/50 GB (25%)
```

- **Memory**: sum of all container memory usage
- **CPU**: sum of all container CPU percentages
- **Disk**: storage pool usage from incus (ZFS pool)

Adds `GetStoragePoolUsage()` to the incus client and `StoragePool` to the config (defaults to `pd-standard`).

Closes #54

## Test plan

- [x] Verify summary line appears below the container table
- [x] Verify memory and CPU totals match individual container values
- [x] Verify disk usage reflects the ZFS storage pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)