### PR TITLE
Embed registry auth script with config-driven values

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,27 @@ permissions:
   contents: write
 
 jobs:
+  version-check:
+    name: Verify version alignment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check migration version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          MIGRATION_VERSION=$(grep -oP '"v[0-9]+\.[0-9]+"' tui/internal/upgrade/upgrade.go | tail -1 | tr -d '"')
+          echo "Git tag: $TAG"
+          echo "Latest migration: $MIGRATION_VERSION"
+          if [ "$TAG" != "$MIGRATION_VERSION" ]; then
+            echo "::error::Version mismatch! Tag is $TAG but latest migration is $MIGRATION_VERSION"
+            echo "See docs/release-process.md for the release process."
+            exit 1
+          fi
+
   build:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    needs: version-check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,77 @@
+# FreeDB Release Process
+
+## Version Alignment Rule
+
+**The git tag, binary version, and migration version must always match.**
+
+When you tag `v1.1`, the binary reports `freedb v1.1`, and the latest migration is `v1.1`. This keeps things simple for users — one version number everywhere.
+
+## How to Ship a Release
+
+### 1. Bundle migration changes into one script
+
+All schema changes, script updates, and platform modifications for a release go into a single migration file:
+
+```
+tui/internal/upgrade/migrations/v1.1.sh
+```
+
+If you need multiple steps, put them all in that one file. Do not create intermediate migration versions (no `v1.1.1.sh`).
+
+### 2. Register the migration
+
+Add the new version to the migrations list in `tui/internal/upgrade/upgrade.go`:
+
+```go
+var migrations = []Migration{
+    // ...existing...
+    {Version: "v1.1", Script: "v1.1.sh"},
+}
+```
+
+### 3. Update the version history
+
+Add an entry to the version table in `README.md`:
+
+```markdown
+| v1.1 | Per-database backups, restore command, architecture detection |
+```
+
+### 4. Merge to main
+
+Get the PR reviewed and merged.
+
+### 5. Tag the release
+
+```bash
+git checkout main && git pull
+git tag -a v1.1 -m "v1.1: Short description of changes"
+git push origin v1.1
+```
+
+This triggers the GitHub Release workflow which builds binaries for linux/amd64, linux/arm64, and darwin/arm64.
+
+### 6. Verify the release
+
+- Check GitHub Releases for the binaries and checksums
+- Download a binary and verify: `./freedb --version` shows `v1.1`
+- Run `sudo freedb upgrade --dry-run` on a test instance — should show `v1.1` as pending
+
+## During Development
+
+Between releases, it's fine to have unreleased migration scripts on feature branches. But before tagging:
+
+- Squash any intermediate migrations into a single file matching the release version
+- Ensure the migration is idempotent (safe to re-run)
+- Test the upgrade path from the previous release
+
+## CI Enforcement
+
+The CI workflow validates that the latest migration version matches the git tag on release builds. If you push a tag `v1.1` but the latest migration is `v1.0`, the build will fail.
+
+## What Not to Do
+
+- Don't create migration files without a corresponding release plan
+- Don't tag a release without a migration (even if it's empty — create a no-op script)
+- Don't auto-tag based on migration changes
+- Don't reuse or amend existing migration scripts after they've been released

--- a/ops/registry-auth.sh
+++ b/ops/registry-auth.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# FreeDB registry credential helper
+# Generates auth.json for private OCI registries (AWS ECR or GCP Artifact Registry)
+# Reads configuration from /opt/freedb/registry-auth.env
+#
+# ENVIRONMENT (via registry-auth.env)
+#   FREEDB_CLOUD        - "aws" or "gcp"
+#   FREEDB_REGISTRY_HOST - registry hostname (e.g., 123456.dkr.ecr.us-east-2.amazonaws.com)
+#   FREEDB_AWS_REGION   - AWS region (only for aws)
+
+CONFIG_FILE="/opt/freedb/registry-auth.env"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo '{"_updated": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "auths": {}}'
+  exit 0
+fi
+
+. "$CONFIG_FILE"
+
+CLOUD="${FREEDB_CLOUD:-}"
+REGISTRY_HOST="${FREEDB_REGISTRY_HOST:-}"
+AWS_REGION="${FREEDB_AWS_REGION:-}"
+
+if [ -z "$CLOUD" ] || [ -z "$REGISTRY_HOST" ]; then
+  echo '{"_updated": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "auths": {}}'
+  exit 0
+fi
+
+TOKEN=""
+if [ "$CLOUD" = "aws" ]; then
+  TOKEN=$(aws ecr get-login-password --region "$AWS_REGION" 2>/dev/null || echo "")
+  if [ -n "$TOKEN" ]; then
+    TOKEN=$(echo -n "AWS:${TOKEN}" | base64 -w0)
+  fi
+elif [ "$CLOUD" = "gcp" ]; then
+  ACCESS_TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
+    http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null || echo "")
+  if [ -n "$ACCESS_TOKEN" ]; then
+    TOKEN=$(echo -n "oauth2accesstoken:${ACCESS_TOKEN}" | base64 -w0)
+  fi
+fi
+
+if [ -n "$TOKEN" ]; then
+  cat << EOF
+{
+  "_updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "auths": {
+    "${REGISTRY_HOST}": {
+      "auth": "${TOKEN}"
+    }
+  }
+}
+EOF
+else
+  echo '{"_updated": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "auths": {}}'
+fi

--- a/platform/scripts/incus.sh
+++ b/platform/scripts/incus.sh
@@ -98,37 +98,23 @@ if [ -n "$KEY_FILE" ] && [ -f "$KEY_FILE" ]; then
 EOF
 elif [ "$CLOUD" = "gcp" ]; then
   echo "Setting up GCP credential helper for Artifact Registry"
+  REGISTRY_HOST="us-central1-docker.pkg.dev"
+  CRON_INTERVAL="*/45 * * * *"  # GCP tokens expire every hour
 
-  sudo tee /usr/local/bin/freedb-registry-auth.sh > /dev/null << 'HELPER'
-#!/bin/bash
-# Credential helper for GCP Artifact Registry
-# Outputs a valid auth.json — falls back to empty auths if token fetch fails
-TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
-  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null || echo "")
+  sudo mkdir -p /opt/freedb
+  sudo tee /opt/freedb/registry-auth.env > /dev/null << EOF
+export FREEDB_CLOUD=gcp
+export FREEDB_REGISTRY_HOST=${REGISTRY_HOST}
+export FREEDB_AWS_REGION=
+EOF
 
-if [ -n "$TOKEN" ]; then
-  AUTH=$(echo -n "oauth2accesstoken:${TOKEN}" | base64 -w0)
-  cat << AUTHEOF
-{
-  "_updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "auths": {
-    "us-central1-docker.pkg.dev": {
-      "auth": "${AUTH}"
-    }
-  }
-}
-AUTHEOF
-else
-  echo "{\"_updated\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"auths\": {}}"
-fi
-HELPER
+  # Install the generic auth script
+  sudo cp "${SCRIPT_DIR}/../../ops/registry-auth.sh" /usr/local/bin/freedb-registry-auth.sh
   sudo chmod +x /usr/local/bin/freedb-registry-auth.sh
 
   /usr/local/bin/freedb-registry-auth.sh | sudo -u incus tee /home/incus/.config/containers/auth.json > /dev/null
 
-  # Refresh the token every 45 minutes (expires every hour)
-  CRON_LINE="*/45 * * * * /usr/local/bin/freedb-registry-auth.sh > /home/incus/.config/containers/auth.json 2>/dev/null"
+  CRON_LINE="${CRON_INTERVAL} /usr/local/bin/freedb-registry-auth.sh > /home/incus/.config/containers/auth.json 2>/dev/null"
   EXISTING=$(sudo -u incus crontab -l 2>/dev/null | grep -v freedb-registry-auth || true)
   echo "${EXISTING:+$EXISTING
 }${CRON_LINE}" | sudo -u incus crontab -
@@ -142,7 +128,6 @@ elif [ "$CLOUD" = "aws" ]; then
   fi
 
   if command -v aws &>/dev/null; then
-    # Auto-detect AWS account ID and region
     AWS_REGION=$(curl -sf -m 2 -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 10" \
       http://169.254.169.254/latest/api/token | \
       xargs -I{} curl -sf -H "X-aws-ec2-metadata-token: {}" \
@@ -159,28 +144,15 @@ elif [ "$CLOUD" = "aws" ]; then
         ECR_HOST="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
         echo "Setting up AWS ECR credential helper for ${ECR_HOST}"
 
-        sudo tee /usr/local/bin/freedb-registry-auth.sh > /dev/null << HELPER
-#!/bin/bash
-# Credential helper for AWS ECR
-# Outputs a valid auth.json — falls back to empty auths if token fetch fails
-TOKEN=\$(aws ecr get-login-password --region ${AWS_REGION} 2>/dev/null || echo "")
+        sudo mkdir -p /opt/freedb
+        sudo tee /opt/freedb/registry-auth.env > /dev/null << EOF
+export FREEDB_CLOUD=aws
+export FREEDB_REGISTRY_HOST=${ECR_HOST}
+export FREEDB_AWS_REGION=${AWS_REGION}
+EOF
 
-if [ -n "\$TOKEN" ]; then
-  AUTH=\$(echo -n "AWS:\${TOKEN}" | base64 -w0)
-  cat << AUTHEOF
-{
-  "_updated": "\$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "auths": {
-    "${ECR_HOST}": {
-      "auth": "\${AUTH}"
-    }
-  }
-}
-AUTHEOF
-else
-  echo "{\"_updated\": \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"auths\": {}}"
-fi
-HELPER
+        # Install the generic auth script
+        sudo cp "${SCRIPT_DIR}/../../ops/registry-auth.sh" /usr/local/bin/freedb-registry-auth.sh
         sudo chmod +x /usr/local/bin/freedb-registry-auth.sh
 
         /usr/local/bin/freedb-registry-auth.sh | sudo -u incus tee /home/incus/.config/containers/auth.json > /dev/null

--- a/tui/internal/upgrade/files/registry-auth.sh
+++ b/tui/internal/upgrade/files/registry-auth.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# FreeDB registry credential helper
+# Generates auth.json for private OCI registries (AWS ECR or GCP Artifact Registry)
+# Reads configuration from /opt/freedb/registry-auth.env
+#
+# ENVIRONMENT (via registry-auth.env)
+#   FREEDB_CLOUD        - "aws" or "gcp"
+#   FREEDB_REGISTRY_HOST - registry hostname (e.g., 123456.dkr.ecr.us-east-2.amazonaws.com)
+#   FREEDB_AWS_REGION   - AWS region (only for aws)
+
+CONFIG_FILE="/opt/freedb/registry-auth.env"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo '{"_updated": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "auths": {}}'
+  exit 0
+fi
+
+. "$CONFIG_FILE"
+
+CLOUD="${FREEDB_CLOUD:-}"
+REGISTRY_HOST="${FREEDB_REGISTRY_HOST:-}"
+AWS_REGION="${FREEDB_AWS_REGION:-}"
+
+if [ -z "$CLOUD" ] || [ -z "$REGISTRY_HOST" ]; then
+  echo '{"_updated": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "auths": {}}'
+  exit 0
+fi
+
+TOKEN=""
+if [ "$CLOUD" = "aws" ]; then
+  TOKEN=$(aws ecr get-login-password --region "$AWS_REGION" 2>/dev/null || echo "")
+  if [ -n "$TOKEN" ]; then
+    TOKEN=$(echo -n "AWS:${TOKEN}" | base64 -w0)
+  fi
+elif [ "$CLOUD" = "gcp" ]; then
+  ACCESS_TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
+    http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null || echo "")
+  if [ -n "$ACCESS_TOKEN" ]; then
+    TOKEN=$(echo -n "oauth2accesstoken:${ACCESS_TOKEN}" | base64 -w0)
+  fi
+fi
+
+if [ -n "$TOKEN" ]; then
+  cat << EOF
+{
+  "_updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "auths": {
+    "${REGISTRY_HOST}": {
+      "auth": "${TOKEN}"
+    }
+  }
+}
+EOF
+else
+  echo '{"_updated": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "auths": {}}'
+fi

--- a/tui/internal/upgrade/migrations/v0.7.sh
+++ b/tui/internal/upgrade/migrations/v0.7.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+# Migration: v0.6 → v0.7
+# - Replace hardcoded registry auth script with config-driven version
+# - Extract existing config values into /opt/freedb/registry-auth.env
+
+echo "=== Migration v0.7: Updatable registry auth script ==="
+
+OLD_SCRIPT="/usr/local/bin/freedb-registry-auth.sh"
+ENV_FILE="/opt/freedb/registry-auth.env"
+
+if [ ! -f "$OLD_SCRIPT" ]; then
+  echo "No registry auth script found, skipping"
+  echo ""
+  echo "=== Migration v0.7 complete ==="
+  exit 0
+fi
+
+# Detect cloud and extract config from the existing script
+CLOUD=""
+REGISTRY_HOST=""
+AWS_REGION=""
+
+if grep -q "aws ecr" "$OLD_SCRIPT" 2>/dev/null; then
+  CLOUD="aws"
+  AWS_REGION=$(grep -oP 'region \K[a-z0-9-]+' "$OLD_SCRIPT" 2>/dev/null || echo "")
+  REGISTRY_HOST=$(grep -oP '[0-9]+\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com' "$OLD_SCRIPT" 2>/dev/null || echo "")
+elif grep -q "metadata.google.internal" "$OLD_SCRIPT" 2>/dev/null; then
+  CLOUD="gcp"
+  REGISTRY_HOST=$(grep -oP '[a-z0-9-]+-docker\.pkg\.dev' "$OLD_SCRIPT" 2>/dev/null || echo "")
+fi
+
+if [ -z "$CLOUD" ] || [ -z "$REGISTRY_HOST" ]; then
+  echo "Could not detect cloud/registry from existing script, skipping"
+  echo ""
+  echo "=== Migration v0.7 complete ==="
+  exit 0
+fi
+
+echo "1. Detected: cloud=$CLOUD, host=$REGISTRY_HOST"
+
+# Write env file
+echo "2. Writing $ENV_FILE..."
+if [ ! -f "$ENV_FILE" ]; then
+  mkdir -p /opt/freedb
+  cat > "$ENV_FILE" << EOF
+export FREEDB_CLOUD=${CLOUD}
+export FREEDB_REGISTRY_HOST=${REGISTRY_HOST}
+export FREEDB_AWS_REGION=${AWS_REGION}
+EOF
+  echo "   Created $ENV_FILE"
+else
+  echo "   $ENV_FILE already exists, skipping"
+fi
+
+# Install the new script
+echo "3. Installing updated auth script..."
+freedb install-auth-script 2>/dev/null || {
+  echo "   Warning: Could not install auth script via freedb."
+  echo "   Manually copy ops/registry-auth.sh to /usr/local/bin/freedb-registry-auth.sh"
+}
+
+# Run it once to verify
+echo "4. Testing new auth script..."
+OUTPUT=$(/usr/local/bin/freedb-registry-auth.sh 2>/dev/null || echo "")
+if echo "$OUTPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('_updated',''))" 2>/dev/null | grep -q "20"; then
+  echo "   Auth script working (has _updated timestamp)"
+  # Write the fresh auth
+  echo "$OUTPUT" | sudo -u incus tee /home/incus/.config/containers/auth.json > /dev/null
+else
+  echo "   Warning: Auth script output missing _updated field"
+fi
+
+echo ""
+echo "=== Migration v0.7 complete ==="

--- a/tui/internal/upgrade/upgrade.go
+++ b/tui/internal/upgrade/upgrade.go
@@ -15,6 +15,9 @@ var migrationFS embed.FS
 //go:embed files/backup-db.sh
 var backupScript []byte
 
+//go:embed files/registry-auth.sh
+var registryAuthScript []byte
+
 const versionFile = "/etc/freedb/version"
 
 type Migration struct {
@@ -28,6 +31,7 @@ var migrations = []Migration{
 	{Version: "v0.4", Script: "v0.4.sh"},
 	{Version: "v0.5", Script: "v0.5.sh"},
 	{Version: "v0.6", Script: "v0.6.sh"},
+	{Version: "v0.7", Script: "v0.7.sh"},
 }
 
 // InstallBackupScript writes the embedded backup script to /opt/freedb/
@@ -37,6 +41,11 @@ func InstallBackupScript() error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(dir, "backup-db.sh"), backupScript, 0755)
+}
+
+// InstallAuthScript writes the embedded registry auth script to /usr/local/bin/
+func InstallAuthScript() error {
+	return os.WriteFile("/usr/local/bin/freedb-registry-auth.sh", registryAuthScript, 0755)
 }
 
 func CurrentVersion() string {

--- a/tui/main.go
+++ b/tui/main.go
@@ -60,6 +60,13 @@ func main() {
 			}
 			fmt.Println("Backup script installed to /opt/freedb/backup-db.sh")
 			os.Exit(0)
+		case "install-auth-script":
+			if err := upgrade.InstallAuthScript(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println("Registry auth script installed to /usr/local/bin/freedb-registry-auth.sh")
+			os.Exit(0)
 		case "acme-email":
 			os.Exit(runAcmeEmail(os.Args[2:]))
 		case "restore":


### PR DESCRIPTION
## Summary

The registry auth script (`freedb-registry-auth.sh`) was generated once during install with hardcoded values and never updated by migrations. This meant fixes (like adding `_updated` timestamp) never reached existing installs.

Now follows the same pattern as `backup-db.sh`:
- Generic script reads config from `/opt/freedb/registry-auth.env`
- Embedded in the binary via `go:embed`
- `freedb install-auth-script` command to install/update
- v0.7 migration extracts config from old script into env file and installs the new version
- Fresh installs write the env file and copy the generic script

Supports both AWS ECR and GCP Artifact Registry.

Closes #59

## Test plan

- [x] Build and deploy to AWS test instance
- [x] Run `sudo freedb upgrade` — v0.7 should detect AWS/ECR config
- [x] Verify `/opt/freedb/registry-auth.env` has correct values
- [x] Verify `_updated` timestamp appears in auth.json
- [x] Verify ECR pulls still work after migration
- [ ] Test fresh GCP install uses the new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)