### PR TITLE
Acquire deploy lock in startApp/restartApp

### DIFF
--- a/tui/internal/tui/manage/model.go
+++ b/tui/internal/tui/manage/model.go
@@ -692,6 +692,12 @@ func (m Model) startApp() tea.Cmd {
 	app := m.app
 	reg := m.registry
 	return func() tea.Msg {
+		lock, err := deploy.AcquireLock()
+		if err != nil {
+			return actionResult{err: fmt.Errorf("a deploy is in progress, please wait")}
+		}
+		defer lock.Release()
+
 		ctx := context.Background()
 		if err := ic.StartContainer(ctx, name); err != nil {
 			return actionResult{err: err}
@@ -716,6 +722,12 @@ func (m Model) restartApp() tea.Cmd {
 	app := m.app
 	reg := m.registry
 	return func() tea.Msg {
+		lock, err := deploy.AcquireLock()
+		if err != nil {
+			return actionResult{err: fmt.Errorf("a deploy is in progress, please wait")}
+		}
+		defer lock.Release()
+
 		ctx := context.Background()
 		_ = ic.StopContainer(ctx, name)
 		if err := ic.StartContainer(ctx, name); err != nil {


### PR DESCRIPTION
## Summary
- `startApp()` and `restartApp()` now acquire `deploy.AcquireLock()` before touching the container
- If a deploy is in progress, surfaces "a deploy is in progress, please wait" instead of racing
- Prevents zombie containers from concurrent restart + deploy

Fixes #67

## Test plan
- [ ] Start a deploy, then try to restart the same app — should show lock error
- [ ] Restart without a deploy in progress — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)