### PR TITLE
Fix database restore: prefix collision, broken pipe, active connections

### DIFF
--- a/tui/internal/db/postgres.go
+++ b/tui/internal/db/postgres.go
@@ -138,6 +138,12 @@ func ListBackupFiles(dbName string) ([]BackupFile, error) {
 		datePart := strings.TrimPrefix(e.Name(), prefix)
 		datePart = strings.TrimSuffix(datePart, ".sql.gz")
 
+		// Guard against prefix collisions (e.g. "myapp" matching "myapp_stage_20260508_...")
+		// The date part must start with 8 digits (YYYYMMDD)
+		if len(datePart) < 8 || datePart[0] < '0' || datePart[0] > '9' {
+			continue
+		}
+
 		info, _ := e.Info()
 		size := int64(0)
 		if info != nil {
@@ -167,6 +173,12 @@ func ListBackupFiles(dbName string) ([]BackupFile, error) {
 // RestoreDatabase restores a database from a gzipped SQL dump file.
 // It drops and recreates the database before restoring.
 func RestoreDatabase(ctx context.Context, ic *incus.Client, dbName, backupPath string) error {
+	// Terminate active connections so dropdb can succeed
+	_, _ = ic.Exec(ctx, dbContainer, []string{
+		"sudo", "-u", "postgres", "psql", "-c",
+		fmt.Sprintf("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()", dbName),
+	})
+
 	// Drop existing database (ignore error if it doesn't exist)
 	_, _ = ic.Exec(ctx, dbContainer, []string{
 		"sudo", "-u", "postgres", "dropdb", "--if-exists", dbName,
@@ -180,14 +192,24 @@ func RestoreDatabase(ctx context.Context, ic *incus.Client, dbName, backupPath s
 		return fmt.Errorf("recreating database %s: %w", dbName, err)
 	}
 
-	// Restore: gunzip the backup and pipe into psql via incus exec
-	// We run this on the host since the backup file is on the host filesystem
-	cmd := fmt.Sprintf("gunzip -c %s | sudo incus exec %s -- sudo -u postgres psql -d %s", backupPath, dbContainer, dbName)
-	execCmd := exec.CommandContext(ctx, "bash", "-c", cmd)
-	output, err := execCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("restoring %s: %s", dbName, strings.TrimSpace(string(output)))
+	// Push the backup file into the container, then restore inside it.
+	// Piping stdin through "incus exec" via a shell pipe is unreliable.
+	remotePath := fmt.Sprintf("/tmp/%s_restore.sql.gz", dbName)
+	pushCmd := exec.CommandContext(ctx, "sudo", "incus", "file", "push", backupPath, dbContainer+remotePath)
+	if output, err := pushCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("pushing backup to container: %s", strings.TrimSpace(string(output)))
 	}
+
+	restoreCmd := fmt.Sprintf("gunzip -c %s | sudo -u postgres psql -d %s", remotePath, dbName)
+	_, err = ic.Exec(ctx, dbContainer, []string{"bash", "-c", restoreCmd})
+	if err != nil {
+		// Clean up temp file even on failure
+		_, _ = ic.Exec(ctx, dbContainer, []string{"rm", "-f", remotePath})
+		return fmt.Errorf("restoring %s: %w", dbName, err)
+	}
+
+	// Clean up temp file
+	_, _ = ic.Exec(ctx, dbContainer, []string{"rm", "-f", remotePath})
 
 	return nil
 }

--- a/tui/internal/tui/databases/model.go
+++ b/tui/internal/tui/databases/model.go
@@ -578,25 +578,35 @@ func (m Model) restoreDatabase(name, backupPath string) tea.Cmd {
 	reg := m.registry
 	return func() tea.Msg {
 		ctx := context.Background()
-		if err := db.RestoreDatabase(ctx, ic, name, backupPath); err != nil {
-			return actionResult{err: err}
-		}
 
-		// Restart the app container that uses this database
-		msg := fmt.Sprintf("Database %q restored", name)
+		// Stop the app container first to prevent active connections
+		// from blocking the database drop
+		var appContainer string
 		if reg != nil {
 			for _, app := range reg.List() {
 				if app.HasDB && app.DBName == name {
-					cName := app.Name
+					appContainer = app.Name
 					if app.ContainerName != "" {
-						cName = app.ContainerName
+						appContainer = app.ContainerName
 					}
-					_ = ic.StopContainer(ctx, cName)
-					_ = ic.StartContainer(ctx, cName)
-					msg += fmt.Sprintf(", restarted %s", cName)
+					_ = ic.StopContainer(ctx, appContainer)
 					break
 				}
 			}
+		}
+
+		if err := db.RestoreDatabase(ctx, ic, name, backupPath); err != nil {
+			// Restart the app even if restore failed
+			if appContainer != "" {
+				_ = ic.StartContainer(ctx, appContainer)
+			}
+			return actionResult{err: err}
+		}
+
+		msg := fmt.Sprintf("Database %q restored", name)
+		if appContainer != "" {
+			_ = ic.StartContainer(ctx, appContainer)
+			msg += fmt.Sprintf(", restarted %s", appContainer)
 		}
 
 		return actionResult{msg: msg}

--- a/tui/main.go
+++ b/tui/main.go
@@ -599,29 +599,37 @@ func runRestore(args []string) int {
 		return 1
 	}
 
-	if err := db.RestoreDatabase(context.Background(), ic, dbName, match.Path); err != nil {
+	// Stop the app container before restoring to avoid active connection issues
+	ctx := context.Background()
+	var appContainer string
+	reg, err := registry.Load("/etc/freedb/registry.json")
+	if err == nil {
+		for _, app := range reg.List() {
+			if app.HasDB && app.DBName == dbName {
+				appContainer = app.Name
+				if app.ContainerName != "" {
+					appContainer = app.ContainerName
+				}
+				fmt.Printf("Stopping %s...\n", appContainer)
+				_ = ic.StopContainer(ctx, appContainer)
+				break
+			}
+		}
+	}
+
+	if err := db.RestoreDatabase(ctx, ic, dbName, match.Path); err != nil {
 		fmt.Fprintf(os.Stderr, "Restore failed: %v\n", err)
+		if appContainer != "" {
+			_ = ic.StartContainer(ctx, appContainer)
+		}
 		return 1
 	}
 
 	fmt.Printf("Database %s restored successfully.\n", dbName)
 
-	// Restart the app container that uses this database
-	reg, err := registry.Load("/etc/freedb/registry.json")
-	if err == nil {
-		for _, app := range reg.List() {
-			if app.HasDB && app.DBName == dbName {
-				cName := app.Name
-				if app.ContainerName != "" {
-					cName = app.ContainerName
-				}
-				fmt.Printf("Restarting %s...\n", cName)
-				ctx := context.Background()
-				_ = ic.StopContainer(ctx, cName)
-				_ = ic.StartContainer(ctx, cName)
-				break
-			}
-		}
+	if appContainer != "" {
+		fmt.Printf("Starting %s...\n", appContainer)
+		_ = ic.StartContainer(ctx, appContainer)
 	}
 	return 0
 }


### PR DESCRIPTION
## Summary
- **Prefix collision**: `aifa-api` backups were matching `aifa-api-stage` files. Now validates the date part starts with a digit after stripping the prefix.
- **Broken pipe**: `gunzip | sudo incus exec ... psql` doesn't work — stdin doesn't pipe through. Now pushes the backup file into the container with `incus file push`, then restores inside.
- **Active connections**: `dropdb` fails if the app has open sessions. Now terminates backends before drop, and stops the app container before restoring (both TUI and CLI).

Fixes #68

## Test plan
- [ ] Restore `aifa-api` — backup picker should not show `aifa-api-stage` files
- [ ] Restore completes successfully (no pipe error)
- [ ] App container is stopped before restore and restarted after
- [ ] CLI `freedb restore <db> <date>` also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)